### PR TITLE
Disable spellcheck on textarea when editing clips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipless",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipless",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/renderer/src/components/clips/Clip.tsx
+++ b/src/renderer/src/components/clips/Clip.tsx
@@ -209,6 +209,7 @@ export function Clip({ clip, index }: ClipProps): React.JSX.Element {
                     })}
                     autoFocus
                     rows={1}
+                    spellCheck={false}
                     style={{
                       resize: 'none',
                       minHeight: '1.2em',
@@ -234,6 +235,7 @@ export function Clip({ clip, index }: ClipProps): React.JSX.Element {
                   className={classNames(styles.textEditor, { [styles.light]: isLight })}
                   autoFocus
                   rows={1}
+                  spellCheck={false}
                   style={{
                     resize: 'none',
                     minHeight: '1.2em',


### PR DESCRIPTION
- Removes unnecessary spellcheck highlighting when editing clips inline - particularly irritating when viewing with syntax highlighting as seen in screenshot:

**Before**
![image](https://github.com/user-attachments/assets/b8414e94-7be9-44d2-9d6d-26ce0aedb07d)

**After**
![image](https://github.com/user-attachments/assets/e0e93b2b-5ec3-4cc7-b36f-762522d5cd45)
