### PR TITLE
Tool launcher ux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipless",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipless",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/renderer/src/components/clips/QuickClipsScanner.module.css
+++ b/src/renderer/src/components/clips/QuickClipsScanner.module.css
@@ -163,13 +163,26 @@
   min-width: 0;
 }
 
+.sectionTitleRow {
+  display: flex;
+  align-items: center;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.selectAllLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  width: 100%;
+}
+
 .sectionTitle {
   font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary);
   margin: 0;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--border-secondary);
 }
 
 /* Matches List */
@@ -291,7 +304,7 @@
 
 .templateButton:disabled {
   opacity: 0.5;
-  cursor: wait;
+  cursor: not-allowed;
 }
 
 .toolDetails {
@@ -318,6 +331,19 @@
   color: var(--text-tertiary);
   font-size: 0.675rem;
   font-style: italic;
+}
+
+.templateConflict {
+  color: #d97706;
+  font-size: 0.7rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.125rem;
+}
+
+.templateConflict.light {
+  color: #b45309;
 }
 
 /* Accordion */

--- a/src/renderer/src/components/clips/QuickClipsScanner.test.tsx
+++ b/src/renderer/src/components/clips/QuickClipsScanner.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeAmbiguousGroups,
+  computeInitialSelection,
+  type CaptureItem,
+} from './quickClipsSelection';
+
+function item(groupName: string, value: string): CaptureItem {
+  return {
+    groupName,
+    value,
+    searchTermId: `term-${groupName}`,
+    uniqueKey: `${groupName}-${value}`,
+  };
+}
+
+describe('computeInitialSelection', () => {
+  it('returns empty set when there are no items', () => {
+    expect(computeInitialSelection([])).toEqual(new Set());
+  });
+
+  it('selects all items when every group is a singleton', () => {
+    const items = [item('url', 'a'), item('ticket', 'T-1'), item('email', 'a@b.c')];
+    expect(computeInitialSelection(items)).toEqual(new Set(['url-a', 'ticket-T-1', 'email-a@b.c']));
+  });
+
+  it('skips groups with multiple instances', () => {
+    const items = [item('url', 'a'), item('url', 'b'), item('ticket', 'T-1')];
+    expect(computeInitialSelection(items)).toEqual(new Set(['ticket-T-1']));
+  });
+
+  it('selects nothing when every group has multiple instances', () => {
+    const items = [
+      item('url', 'a'),
+      item('url', 'b'),
+      item('ticket', 'T-1'),
+      item('ticket', 'T-2'),
+    ];
+    expect(computeInitialSelection(items)).toEqual(new Set());
+  });
+
+  it('returns empty set when total items exceed 5, even if all are singletons', () => {
+    const items = [
+      item('a', '1'),
+      item('b', '2'),
+      item('c', '3'),
+      item('d', '4'),
+      item('e', '5'),
+      item('f', '6'),
+    ];
+    expect(computeInitialSelection(items)).toEqual(new Set());
+  });
+
+  it('still applies the singleton rule at exactly 5 items', () => {
+    const items = [
+      item('url', 'a'),
+      item('url', 'b'),
+      item('ticket', 'T-1'),
+      item('email', 'x@y.z'),
+      item('phone', '555'),
+    ];
+    expect(computeInitialSelection(items)).toEqual(
+      new Set(['ticket-T-1', 'email-x@y.z', 'phone-555'])
+    );
+  });
+});
+
+describe('computeAmbiguousGroups', () => {
+  it('returns empty when nothing is selected', () => {
+    const items = [item('url', 'a'), item('url', 'b')];
+    expect(computeAmbiguousGroups(items, new Set())).toEqual(new Set());
+  });
+
+  it('returns empty when each selected group has a single value', () => {
+    const items = [item('url', 'a'), item('url', 'b'), item('ticket', 'T-1')];
+    expect(computeAmbiguousGroups(items, new Set(['url-a', 'ticket-T-1']))).toEqual(new Set());
+  });
+
+  it('flags a group when more than one value is selected for it', () => {
+    const items = [item('url', 'a'), item('url', 'b'), item('ticket', 'T-1')];
+    expect(computeAmbiguousGroups(items, new Set(['url-a', 'url-b', 'ticket-T-1']))).toEqual(
+      new Set(['url'])
+    );
+  });
+
+  it('flags multiple groups independently', () => {
+    const items = [
+      item('url', 'a'),
+      item('url', 'b'),
+      item('ticket', 'T-1'),
+      item('ticket', 'T-2'),
+      item('email', 'x@y.z'),
+    ];
+    const selected = new Set(['url-a', 'url-b', 'ticket-T-1', 'ticket-T-2', 'email-x@y.z']);
+    expect(computeAmbiguousGroups(items, selected)).toEqual(new Set(['url', 'ticket']));
+  });
+
+  it('ignores unselected items even if other items in the group are selected', () => {
+    const items = [item('url', 'a'), item('url', 'b'), item('url', 'c')];
+    expect(computeAmbiguousGroups(items, new Set(['url-a']))).toEqual(new Set());
+  });
+});

--- a/src/renderer/src/components/clips/QuickClipsScanner.tsx
+++ b/src/renderer/src/components/clips/QuickClipsScanner.tsx
@@ -4,13 +4,11 @@ import { PatternMatch, QuickTool, Template } from '../../../../shared/types';
 import { useTheme } from '../../providers/theme';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styles from './QuickClipsScanner.module.css';
-
-interface CaptureItem {
-  groupName: string;
-  value: string;
-  searchTermId: string;
-  uniqueKey: string;
-}
+import {
+  computeInitialSelection,
+  computeAmbiguousGroups,
+  type CaptureItem,
+} from './quickClipsSelection';
 
 interface QuickClipsScannerProps {
   isOpen: boolean;
@@ -139,6 +137,19 @@ export function QuickClipsScanner({
     }
   }, [matchedTemplates, accordionInitialized]);
 
+  // When tools become available, auto-expand that section
+  useEffect(() => {
+    if (!accordionInitialized) return;
+    if (availableTools.length > 0) {
+      setExpandedSections((prev) => {
+        if (prev.has('tools')) return prev;
+        const next = new Set(prev);
+        next.add('tools');
+        return next;
+      });
+    }
+  }, [availableTools, accordionInitialized]);
+
   const toggleSection = (section: AccordionSection) => {
     setExpandedSections((prev) => {
       const next = new Set(prev);
@@ -199,7 +210,7 @@ export function QuickClipsScanner({
 
       const items = Array.from(captureMap.values());
       setCaptureItems(items);
-      setSelectedCaptureItems(new Set(items.map((item) => item.uniqueKey)));
+      setSelectedCaptureItems(computeInitialSelection(items));
     } catch (error) {
       console.error('Failed to scan content:', error);
       setMatches([]);
@@ -295,6 +306,22 @@ export function QuickClipsScanner({
       updateMatchedTemplates();
     }
   }, [captureItems, templates, selectedCaptureItems, updateMatchedTemplates]);
+
+  const allCapturesSelected =
+    captureItems.length > 0 && selectedCaptureItems.size === captureItems.length;
+
+  const ambiguousGroups = useMemo(
+    () => computeAmbiguousGroups(captureItems, selectedCaptureItems),
+    [captureItems, selectedCaptureItems]
+  );
+
+  const handleToggleAllCaptures = () => {
+    if (allCapturesSelected) {
+      setSelectedCaptureItems(new Set());
+    } else {
+      setSelectedCaptureItems(new Set(captureItems.map((item) => item.uniqueKey)));
+    }
+  };
 
   const handleCaptureItemToggle = (uniqueKey: string) => {
     const newSelected = new Set(selectedCaptureItems);
@@ -447,9 +474,27 @@ export function QuickClipsScanner({
           <>
             {/* Left Side - Capture Items Section */}
             <div className={classNames(styles.section, styles.leftSection)}>
-              <h3 className={classNames(styles.sectionTitle, { [styles.light]: isLight })}>
-                Found Patterns ({captureItems.length})
-              </h3>
+              <div className={classNames(styles.sectionTitleRow, { [styles.light]: isLight })}>
+                <label className={styles.selectAllLabel}>
+                  <input
+                    type="checkbox"
+                    checked={allCapturesSelected}
+                    ref={(el) => {
+                      if (el) {
+                        el.indeterminate = selectedCaptureItems.size > 0 && !allCapturesSelected;
+                      }
+                    }}
+                    onChange={handleToggleAllCaptures}
+                    className={styles.checkbox}
+                    aria-label={
+                      allCapturesSelected ? 'Deselect all patterns' : 'Select all patterns'
+                    }
+                  />
+                  <h3 className={classNames(styles.sectionTitle, { [styles.light]: isLight })}>
+                    Found Patterns ({captureItems.length})
+                  </h3>
+                </label>
+              </div>
               <div className={styles.matchesList}>
                 {captureItems.map((item) => {
                   const isSelected = selectedCaptureItems.has(item.uniqueKey);
@@ -664,46 +709,67 @@ export function QuickClipsScanner({
   function renderTemplateList(templateList: Template[], showNamedTokens: boolean) {
     return (
       <div className={styles.toolsList}>
-        {templateList.map((template) => (
-          <div
-            key={template.id}
-            className={classNames(styles.toolItem, { [styles.light]: isLight })}
-          >
-            <button
-              className={classNames(styles.toolLabel, styles.templateButton)}
-              onClick={() => handleTemplateSelect(template)}
-              disabled={generatingTemplateId === template.id}
+        {templateList.map((template) => {
+          const conflicts = showNamedTokens
+            ? extractNamedTokens(template.content).filter((t) => ambiguousGroups.has(t))
+            : [];
+          const isAmbiguous = conflicts.length > 0;
+          const disabled = generatingTemplateId === template.id || isAmbiguous;
+
+          return (
+            <div
+              key={template.id}
+              className={classNames(styles.toolItem, { [styles.light]: isLight })}
             >
-              <div className={styles.toolDetails}>
-                <div
-                  className={classNames(styles.toolName, {
-                    [styles.light]: isLight,
-                  })}
-                >
-                  {generatingTemplateId === template.id ? (
-                    <FontAwesomeIcon icon="spinner" spin />
-                  ) : (
-                    <FontAwesomeIcon icon="file-lines" />
-                  )}{' '}
-                  {template.name}
+              <button
+                className={classNames(styles.toolLabel, styles.templateButton)}
+                onClick={() => handleTemplateSelect(template)}
+                disabled={disabled}
+                title={
+                  isAmbiguous
+                    ? `Multiple values selected for ${conflicts.map((c) => `"${c}"`).join(', ')}. Pick a single value per group to use this template.`
+                    : undefined
+                }
+              >
+                <div className={styles.toolDetails}>
+                  <div
+                    className={classNames(styles.toolName, {
+                      [styles.light]: isLight,
+                    })}
+                  >
+                    {generatingTemplateId === template.id ? (
+                      <FontAwesomeIcon icon="spinner" spin />
+                    ) : (
+                      <FontAwesomeIcon icon="file-lines" />
+                    )}{' '}
+                    {template.name}
+                  </div>
+                  <div
+                    className={classNames(styles.toolGroups, {
+                      [styles.light]: isLight,
+                    })}
+                  >
+                    Tokens:{' '}
+                    {showNamedTokens
+                      ? extractAllTokens(template.content).join(', ')
+                      : extractAllTokens(template.content)
+                          .filter((t) => /^c\d+$/.test(t))
+                          .map((t) => `{${t}}`)
+                          .join(', ')}
+                  </div>
+                  {isAmbiguous && (
+                    <div
+                      className={classNames(styles.templateConflict, { [styles.light]: isLight })}
+                    >
+                      <FontAwesomeIcon icon="triangle-exclamation" /> Pick a single value for{' '}
+                      {conflicts.map((c) => `"${c}"`).join(', ')} to use this template.
+                    </div>
+                  )}
                 </div>
-                <div
-                  className={classNames(styles.toolGroups, {
-                    [styles.light]: isLight,
-                  })}
-                >
-                  Tokens:{' '}
-                  {showNamedTokens
-                    ? extractAllTokens(template.content).join(', ')
-                    : extractAllTokens(template.content)
-                        .filter((t) => /^c\d+$/.test(t))
-                        .map((t) => `{${t}}`)
-                        .join(', ')}
-                </div>
-              </div>
-            </button>
-          </div>
-        ))}
+              </button>
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/src/renderer/src/components/clips/quickClipsSelection.ts
+++ b/src/renderer/src/components/clips/quickClipsSelection.ts
@@ -1,0 +1,44 @@
+export interface CaptureItem {
+  groupName: string;
+  value: string;
+  searchTermId: string;
+  uniqueKey: string;
+}
+
+/**
+ * Compute which capture items should be pre-selected.
+ * Rules:
+ *  - If more than 5 capture items total, select none (force explicit choice).
+ *  - Otherwise, pre-select only items whose groupName appears exactly once
+ *    across the full list (singletons). Groups with multiple values stay
+ *    unselected so the user picks which value to use.
+ */
+export function computeInitialSelection(items: CaptureItem[]): Set<string> {
+  if (items.length > 5) return new Set();
+  const groupCounts = new Map<string, number>();
+  items.forEach((item) => {
+    groupCounts.set(item.groupName, (groupCounts.get(item.groupName) ?? 0) + 1);
+  });
+  return new Set(
+    items.filter((item) => groupCounts.get(item.groupName) === 1).map((item) => item.uniqueKey)
+  );
+}
+
+/**
+ * Identify capture groups where the user has selected more than one value.
+ * Templates can only bind a single value per token, so any template needing
+ * one of these groups is ambiguous.
+ */
+export function computeAmbiguousGroups(items: CaptureItem[], selected: Set<string>): Set<string> {
+  const counts = new Map<string, number>();
+  items.forEach((item) => {
+    if (selected.has(item.uniqueKey)) {
+      counts.set(item.groupName, (counts.get(item.groupName) ?? 0) + 1);
+    }
+  });
+  return new Set(
+    Array.from(counts.entries())
+      .filter(([, n]) => n > 1)
+      .map(([g]) => g)
+  );
+}

--- a/src/renderer/src/fontawesome.ts
+++ b/src/renderer/src/fontawesome.ts
@@ -30,6 +30,7 @@ import {
   faChevronRight,
   faFileLines,
   faGear,
+  faTriangleExclamation,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -62,5 +63,6 @@ library.add(
   faRocket,
   faChevronRight,
   faFileLines,
-  faGear
+  faGear,
+  faTriangleExclamation
 );


### PR DESCRIPTION
### Summary

- **Tool Launcher**: Smarter default selection and clearer template conflict feedback in QuickClipsScanner.

#### Added

- "Select all / deselect all" checkbox with indeterminate state in the Found Patterns header.
- `quickClipsSelection.ts` helper module with `computeInitialSelection` and `computeAmbiguousGroups`, plus unit tests in `QuickClipsScanner.test.tsx`.
- Inline warning (with triangle-exclamation icon) on templates whose tokens map to multiple selected values, naming the conflicting groups.
- Auto-expand of the Tools accordion section when tools become available.

#### Changed

- Initial capture selection: when >5 patterns are found, none are pre-selected; otherwise only singleton groups are pre-selected so the user explicitly picks among duplicates.
- Templates with ambiguous token bindings are now disabled (with tooltip + inline message) instead of silently using an arbitrary value.
- Disabled template button cursor switched from `wait` to `not-allowed`.
- Section title row restructured to host the select-all control alongside the heading.

#### Fixed

- Ambiguity in template generation when multiple values were captured for the same named group.

#### Removed

- Local `CaptureItem` interface in `QuickClipsScanner.tsx` (now imported from the shared selection helper).