### PR TITLE
Implement System startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipless",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipless",
-      "version": "1.7.5",
+      "version": "1.7.6",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/main/app/index.ts
+++ b/src/main/app/index.ts
@@ -7,6 +7,7 @@ import { configureAutoUpdater, setupAutoUpdaterEvents } from '../updater';
 import { setupMainIPC } from '../ipc';
 import { initializeWindowSystem, getMainWindow, getWindowBounds } from '../window';
 import { applyWindowSettings } from '../window/settings';
+import { applyAutoStart } from '../autoStart';
 
 export async function initializeApp(): Promise<void> {
   // Set app user model id for windows
@@ -29,7 +30,7 @@ export async function initializeApp(): Promise<void> {
   ]);
 
   // Set up callback to re-apply window settings and notify renderer after background storage loading completes
-  storage.setOnBackgroundLoadComplete(() => {
+  storage.setOnBackgroundLoadComplete(async () => {
     const mainWindow = getMainWindow();
     if (mainWindow) {
       console.log('Background storage loading complete, re-applying window settings');
@@ -37,6 +38,14 @@ export async function initializeApp(): Promise<void> {
 
       // Notify renderer that storage data is ready for re-fetching
       mainWindow.webContents.send('storage-ready');
+    }
+
+    // Reconcile OS login-item state with persisted setting
+    try {
+      const settings = await storage.getSettings();
+      applyAutoStart(settings.autoStart);
+    } catch (error) {
+      console.error('Failed to apply auto-start setting on startup:', error);
     }
   });
 

--- a/src/main/autoStart/index.test.ts
+++ b/src/main/autoStart/index.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    setLoginItemSettings: vi.fn(),
+  },
+}));
+
+import { app } from 'electron';
+import { applyAutoStart, isAutoStartSupported } from './index';
+
+describe('autoStart', () => {
+  const originalPlatform = process.platform;
+
+  const setPlatform = (platform: NodeJS.Platform): void => {
+    Object.defineProperty(process, 'platform', { value: platform });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  describe('isAutoStartSupported', () => {
+    it('returns true on win32', () => {
+      setPlatform('win32');
+      expect(isAutoStartSupported()).toBe(true);
+    });
+
+    it('returns true on darwin', () => {
+      setPlatform('darwin');
+      expect(isAutoStartSupported()).toBe(true);
+    });
+
+    it('returns false on linux', () => {
+      setPlatform('linux');
+      expect(isAutoStartSupported()).toBe(false);
+    });
+  });
+
+  describe('applyAutoStart', () => {
+    it('calls setLoginItemSettings with openAtLogin true on win32', () => {
+      setPlatform('win32');
+      applyAutoStart(true);
+      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
+    });
+
+    it('calls setLoginItemSettings with openAtLogin false on win32', () => {
+      setPlatform('win32');
+      applyAutoStart(false);
+      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+    });
+
+    it('calls setLoginItemSettings on darwin', () => {
+      setPlatform('darwin');
+      applyAutoStart(true);
+      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
+    });
+
+    it('does not call setLoginItemSettings on linux', () => {
+      setPlatform('linux');
+      applyAutoStart(true);
+      expect(app.setLoginItemSettings).not.toHaveBeenCalled();
+    });
+
+    it('swallows errors thrown by setLoginItemSettings', () => {
+      setPlatform('win32');
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(app.setLoginItemSettings).mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+
+      expect(() => applyAutoStart(true)).not.toThrow();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to apply auto-start setting:',
+        expect.any(Error)
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/main/autoStart/index.ts
+++ b/src/main/autoStart/index.ts
@@ -1,0 +1,15 @@
+import { app } from 'electron';
+
+export const isAutoStartSupported = (): boolean => process.platform !== 'linux';
+
+export const applyAutoStart = (enabled: boolean): void => {
+  if (!isAutoStartSupported()) {
+    return;
+  }
+
+  try {
+    app.setLoginItemSettings({ openAtLogin: enabled });
+  } catch (error) {
+    console.error('Failed to apply auto-start setting:', error);
+  }
+};

--- a/src/main/clipboard/ipc.ts
+++ b/src/main/clipboard/ipc.ts
@@ -27,6 +27,7 @@ import {
   importData,
   clearAllData,
 } from './storage-integration';
+import { applyAutoStart } from '../autoStart';
 import {
   getAllTemplates,
   createTemplate,
@@ -120,9 +121,11 @@ export function setupClipboardIPC(mainWindow: BrowserWindow | null): void {
       saveClips(clips, lockedIndices)
   );
   ipcMain.handle('storage-get-settings', async () => getSettings());
-  ipcMain.handle('storage-save-settings', async (_event, settings: UserSettings) =>
-    saveSettings(settings)
-  );
+  ipcMain.handle('storage-save-settings', async (_event, settings: UserSettings) => {
+    const result = await saveSettings(settings);
+    applyAutoStart(settings.autoStart);
+    return result;
+  });
   ipcMain.handle('storage-get-stats', async () => getStorageStats());
   ipcMain.handle('storage-export-data', async () => exportData());
   ipcMain.handle('storage-import-data', async (_event, jsonData: string) => importData(jsonData));

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -12,6 +12,7 @@ import {
 } from '../window/creation';
 import { applyWindowSettings } from '../window/settings';
 import { checkForUpdatesWithRetry } from '../updater';
+import { applyAutoStart } from '../autoStart';
 
 export function setupMainIPC(): void {
   // IPC test
@@ -34,6 +35,9 @@ export function setupMainIPC(): void {
     try {
       // Save settings to storage
       await storage.saveSettings(settings);
+
+      // Apply auto-start setting to OS login items
+      applyAutoStart(settings.autoStart);
 
       // Apply window settings immediately
       const mainWindow = getMainWindow();

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     electron: ElectronAPI;
     api: {
+      platform: NodeJS.Platform;
       checkForUpdates: () => Promise<any>;
       downloadUpdate: () => Promise<any>;
       quitAndInstall: () => Promise<void>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,9 @@ import type {
 
 // Custom APIs for renderer
 const api = {
+  // Platform info
+  platform: process.platform,
+
   // Auto-updater APIs
   checkForUpdates: () => electronAPI.ipcRenderer.invoke('check-for-updates'),
   downloadUpdate: () => electronAPI.ipcRenderer.invoke('download-update'),

--- a/src/renderer/src/components/settings/usersettings/ApplicationSettings.test.tsx
+++ b/src/renderer/src/components/settings/usersettings/ApplicationSettings.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { ApplicationSettings } from './ApplicationSettings';
+import type { UserSettings } from '../../../../../shared/types';
+
+vi.mock('../../../providers/theme', () => ({
+  useTheme: () => ({
+    isLight: false,
+    isDark: true,
+    theme: 'dark',
+    effectiveTheme: 'dark',
+    setTheme: vi.fn(),
+  }),
+}));
+
+const baseSettings: UserSettings = {
+  maxClips: 25,
+  startMinimized: false,
+  autoStart: true,
+  theme: 'system',
+  windowTransparency: 0,
+  transparencyEnabled: false,
+  opaqueWhenFocused: true,
+  alwaysOnTop: false,
+  rememberWindowPosition: true,
+  showNotifications: false,
+  codeDetectionEnabled: true,
+} as UserSettings;
+
+interface RenderOptions {
+  overrides?: Partial<UserSettings>;
+  saving?: boolean;
+  tempMaxClips?: number | null;
+  debounceTimeout?: NodeJS.Timeout | null;
+}
+
+const renderComponent = ({
+  overrides = {},
+  saving = false,
+  tempMaxClips = null,
+  debounceTimeout = null,
+}: RenderOptions = {}) => {
+  const onSettingChange = vi.fn();
+  const onMaxClipsChange = vi.fn();
+  render(
+    <ApplicationSettings
+      settings={{ ...baseSettings, ...overrides }}
+      onSettingChange={onSettingChange}
+      onMaxClipsChange={onMaxClipsChange}
+      saving={saving}
+      tempMaxClips={tempMaxClips}
+      debounceTimeout={debounceTimeout}
+    />
+  );
+  return { onSettingChange, onMaxClipsChange };
+};
+
+const setPlatform = (platform: NodeJS.Platform): void => {
+  (window.api as { platform: NodeJS.Platform }).platform = platform;
+};
+
+describe('ApplicationSettings - Auto Start toggle', () => {
+  const originalPlatform = (window.api as { platform: NodeJS.Platform }).platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    cleanup();
+  });
+
+  it('shows normal description and enabled toggle on win32', () => {
+    setPlatform('win32');
+    renderComponent({ overrides: { autoStart: true } });
+
+    expect(
+      screen.getByText('Start Clipless automatically when your computer boots up')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Not available on Linux')).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('checkbox', { name: 'Auto Start with System' });
+    expect(toggle).not.toBeDisabled();
+    expect(toggle).toBeChecked();
+  });
+
+  it('shows normal description and enabled toggle on darwin', () => {
+    setPlatform('darwin');
+    renderComponent({ overrides: { autoStart: true } });
+
+    const toggle = screen.getByRole('checkbox', { name: 'Auto Start with System' });
+    expect(toggle).not.toBeDisabled();
+    expect(toggle).toBeChecked();
+  });
+
+  it('disables toggle and shows "Not available on Linux" on linux', () => {
+    setPlatform('linux');
+    renderComponent({ overrides: { autoStart: true } });
+
+    expect(screen.getByText('Not available on Linux')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Start Clipless automatically when your computer boots up')
+    ).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('checkbox', { name: 'Auto Start with System' });
+    expect(toggle).toBeDisabled();
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('forwards Auto Start toggle changes to onSettingChange on supported platforms', () => {
+    setPlatform('win32');
+    const { onSettingChange } = renderComponent({ overrides: { autoStart: false } });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Auto Start with System' }));
+    expect(onSettingChange).toHaveBeenCalledWith('autoStart', true);
+  });
+});
+
+describe('ApplicationSettings - other settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders Maximum Clips input with current value and forwards changes', () => {
+    const { onMaxClipsChange } = renderComponent({ overrides: { maxClips: 42 } });
+    const input = screen.getByLabelText('Maximum Clips') as HTMLInputElement;
+    expect(input.value).toBe('42');
+
+    fireEvent.change(input, { target: { value: '50' } });
+    expect(onMaxClipsChange).toHaveBeenCalledWith(50);
+  });
+
+  it('uses tempMaxClips value over settings.maxClips and shows pending hint', () => {
+    renderComponent({
+      overrides: { maxClips: 42 },
+      tempMaxClips: 77,
+      debounceTimeout: setTimeout(() => {}, 1000),
+    });
+    expect((screen.getByLabelText(/Maximum Clips/) as HTMLInputElement).value).toBe('77');
+    expect(screen.getByText('Change pending...')).toBeInTheDocument();
+  });
+
+  it('disables all controls when saving', () => {
+    renderComponent({ saving: true });
+    expect(screen.getByLabelText(/Maximum Clips/)).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'Start Minimized' })).toBeDisabled();
+    expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'Show Notifications' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'Code Detection & Highlighting' })).toBeDisabled();
+  });
+
+  it('forwards Start Minimized toggle changes', () => {
+    const { onSettingChange } = renderComponent({ overrides: { startMinimized: false } });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Start Minimized' }));
+    expect(onSettingChange).toHaveBeenCalledWith('startMinimized', true);
+  });
+
+  it('forwards theme changes', () => {
+    const { onSettingChange } = renderComponent({ overrides: { theme: 'system' } });
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'dark' } });
+    expect(onSettingChange).toHaveBeenCalledWith('theme', 'dark');
+  });
+
+  it('falls back to "system" when theme is undefined', () => {
+    renderComponent({ overrides: { theme: undefined as unknown as UserSettings['theme'] } });
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('system');
+  });
+
+  it('forwards Show Notifications toggle changes', () => {
+    const { onSettingChange } = renderComponent({ overrides: { showNotifications: false } });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Show Notifications' }));
+    expect(onSettingChange).toHaveBeenCalledWith('showNotifications', true);
+  });
+
+  it('forwards Code Detection toggle changes', () => {
+    const { onSettingChange } = renderComponent({ overrides: { codeDetectionEnabled: true } });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Code Detection & Highlighting' }));
+    expect(onSettingChange).toHaveBeenCalledWith('codeDetectionEnabled', false);
+  });
+
+  it('treats undefined showNotifications/codeDetectionEnabled as defaults', () => {
+    renderComponent({
+      overrides: {
+        showNotifications: undefined as unknown as boolean,
+        codeDetectionEnabled: undefined as unknown as boolean,
+      },
+    });
+    expect(screen.getByRole('checkbox', { name: 'Show Notifications' })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Code Detection & Highlighting' })).toBeChecked();
+  });
+});

--- a/src/renderer/src/components/settings/usersettings/ApplicationSettings.tsx
+++ b/src/renderer/src/components/settings/usersettings/ApplicationSettings.tsx
@@ -24,6 +24,7 @@ export const ApplicationSettings: React.FC<ApplicationSettingsProps> = ({
   debounceTimeout,
 }) => {
   const { isLight } = useTheme();
+  const isLinux = window.api.platform === 'linux';
 
   return (
     <div className={styles.section}>
@@ -82,12 +83,16 @@ export const ApplicationSettings: React.FC<ApplicationSettingsProps> = ({
         {/* Auto Start Setting */}
         <SettingItem
           label="Auto Start with System"
-          description="Start Clipless automatically when your computer boots up"
+          description={
+            isLinux
+              ? 'Not available on Linux'
+              : 'Start Clipless automatically when your computer boots up'
+          }
         >
           <ToggleSwitch
-            checked={settings.autoStart}
+            checked={!isLinux && settings.autoStart}
             onChange={(checked) => onSettingChange('autoStart', checked)}
-            disabled={saving}
+            disabled={saving || isLinux}
             label="Auto Start with System"
           />
         </SettingItem>

--- a/src/renderer/src/test-setup.ts
+++ b/src/renderer/src/test-setup.ts
@@ -18,6 +18,7 @@ Object.defineProperty(window, 'matchMedia', {
 
 // Mock window.api for renderer tests
 const createMockApi = () => ({
+  platform: 'win32' as NodeJS.Platform,
   storageGetSettings: vi.fn().mockResolvedValue({
     maxClips: 100,
     startMinimized: false,


### PR DESCRIPTION
### Summary

- **Auto Start with System**: The setting was persisted but never registered with the OS — toggling it had no effect on Windows or macOS, and the option appeared usable on Linux where Electron does not support it.

#### Added

- `src/main/autoStart/` module exposing `applyAutoStart(enabled)` and `isAutoStartSupported()`. Wraps `app.setLoginItemSettings({ openAtLogin })` with platform guard (Linux no-op) and error handling.
- `platform: process.platform` exposed on `window.api` via preload so the renderer can branch on OS without leaking `process` into the renderer.
- Unit tests for the new `autoStart` module (win32/darwin/linux behavior, error swallowing).
- Unit tests for `ApplicationSettings` covering the Linux gating and the remaining settings controls.

#### Changed

- `src/main/app/index.ts` — on startup, after secure storage finishes loading, reconciles the OS login-item state with the persisted `autoStart` setting.
- `src/main/ipc/index.ts` (`settings-changed` handler) and `src/main/clipboard/ipc.ts` (`storage-save-settings` handler) now apply `autoStart` to the OS after persisting.
- `ApplicationSettings.tsx` — Auto Start toggle is disabled on Linux and its description switches to "Not available on Linux".
- `src/renderer/src/test-setup.ts` — mocked `window.api` now includes `platform`.

#### Fixed

- Enabling "Auto Start with System" now actually registers Clipless as a login item on Windows (DPAPI/registry) and macOS (LaunchServices). Disabling it removes the registration.

#### Removed

- N/A