### PR TITLE
Better Auto Update UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipless",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipless",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/main/updater/index.test.ts
+++ b/src/main/updater/index.test.ts
@@ -8,7 +8,7 @@ interface FakeAutoUpdater extends EventEmitter {
   quitAndInstall: ReturnType<typeof vi.fn>;
 }
 
-const { isMock, fakeAutoUpdater, showMessageBox, getSettings } = vi.hoisted(() => {
+const { isMock, fakeAutoUpdater, getSettings } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { EventEmitter: NodeEventEmitter } = require('events');
   const updater = new NodeEventEmitter();
@@ -20,7 +20,6 @@ const { isMock, fakeAutoUpdater, showMessageBox, getSettings } = vi.hoisted(() =
   return {
     isMock: { dev: false },
     fakeAutoUpdater: updater as FakeAutoUpdater,
-    showMessageBox: vi.fn(),
     getSettings: vi.fn(),
   };
 });
@@ -31,12 +30,6 @@ vi.mock('@electron-toolkit/utils', () => ({
 
 vi.mock('electron-updater', () => ({
   autoUpdater: fakeAutoUpdater,
-}));
-
-vi.mock('electron', () => ({
-  dialog: {
-    showMessageBox: (...args: unknown[]) => showMessageBox(...args),
-  },
 }));
 
 vi.mock('../storage', () => ({
@@ -54,6 +47,16 @@ import {
 
 const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
+const makeWindow = (
+  overrides: Partial<{ destroyed: boolean; send: ReturnType<typeof vi.fn> }> = {}
+): Parameters<typeof runAutomaticUpdateCheck>[0] => {
+  const send = overrides.send ?? vi.fn();
+  return {
+    isDestroyed: () => overrides.destroyed ?? false,
+    webContents: { send },
+  } as unknown as Parameters<typeof runAutomaticUpdateCheck>[0];
+};
+
 beforeEach(() => {
   isMock.dev = false;
   fakeAutoUpdater.removeAllListeners();
@@ -61,7 +64,6 @@ beforeEach(() => {
   fakeAutoUpdater.autoInstallOnAppQuit = false;
   fakeAutoUpdater.checkForUpdates.mockReset().mockResolvedValue(undefined);
   fakeAutoUpdater.quitAndInstall.mockReset();
-  showMessageBox.mockReset();
   getSettings.mockReset();
 });
 
@@ -113,119 +115,91 @@ describe('setupAutoUpdaterEvents', () => {
 });
 
 describe('runAutomaticUpdateCheck', () => {
-  const parentWindow = {} as Parameters<typeof runAutomaticUpdateCheck>[0];
-
   it('is a no-op in dev mode', async () => {
     isMock.dev = true;
-    await runAutomaticUpdateCheck(parentWindow);
+    await runAutomaticUpdateCheck(makeWindow());
     expect(getSettings).not.toHaveBeenCalled();
     expect(fakeAutoUpdater.checkForUpdates).not.toHaveBeenCalled();
   });
 
   it('returns silently when settings load throws', async () => {
     getSettings.mockRejectedValue(new Error('disk on fire'));
-    await runAutomaticUpdateCheck(parentWindow);
+    await runAutomaticUpdateCheck(makeWindow());
     expect(fakeAutoUpdater.checkForUpdates).not.toHaveBeenCalled();
   });
 
   it('skips the check when automaticUpdates is false', async () => {
     getSettings.mockResolvedValue({ automaticUpdates: false });
-    await runAutomaticUpdateCheck(parentWindow);
+    await runAutomaticUpdateCheck(makeWindow());
     expect(fakeAutoUpdater.checkForUpdates).not.toHaveBeenCalled();
   });
 
   it('runs the check when automaticUpdates is true and flips autoDownload', async () => {
     getSettings.mockResolvedValue({ automaticUpdates: true });
-    await runAutomaticUpdateCheck(parentWindow);
+    await runAutomaticUpdateCheck(makeWindow());
     expect(fakeAutoUpdater.autoDownload).toBe(true);
     expect(fakeAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
   });
 
   it('treats undefined automaticUpdates as enabled', async () => {
     getSettings.mockResolvedValue({});
-    await runAutomaticUpdateCheck(parentWindow);
+    await runAutomaticUpdateCheck(makeWindow());
     expect(fakeAutoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
   });
 
   it('silently swallows a checkForUpdates rejection and clears listeners', async () => {
     getSettings.mockResolvedValue({ automaticUpdates: true });
     fakeAutoUpdater.checkForUpdates.mockRejectedValueOnce(new Error('network'));
-    await expect(runAutomaticUpdateCheck(parentWindow)).resolves.toBeUndefined();
+    await expect(runAutomaticUpdateCheck(makeWindow())).resolves.toBeUndefined();
     expect(fakeAutoUpdater.listenerCount('update-downloaded')).toBe(0);
     expect(fakeAutoUpdater.listenerCount('error')).toBe(0);
   });
 
   it('clears the update-downloaded listener if an error event fires mid-download', async () => {
     getSettings.mockResolvedValue({ automaticUpdates: true });
-    await runAutomaticUpdateCheck(parentWindow);
+    const send = vi.fn();
+    await runAutomaticUpdateCheck(makeWindow({ send }));
     expect(fakeAutoUpdater.listenerCount('update-downloaded')).toBe(1);
 
     fakeAutoUpdater.emit('error', new Error('mid-download boom'));
 
     expect(fakeAutoUpdater.listenerCount('update-downloaded')).toBe(0);
     expect(fakeAutoUpdater.listenerCount('error')).toBe(0);
-    expect(showMessageBox).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 
-  it('shows dialog with parent window and calls quitAndInstall when user picks Restart Now', async () => {
+  it('sends update-downloaded IPC with version to the renderer when download completes', async () => {
     getSettings.mockResolvedValue({ automaticUpdates: true });
-    showMessageBox.mockResolvedValue({ response: 0 });
+    const send = vi.fn();
+    const win = makeWindow({ send });
 
-    await runAutomaticUpdateCheck(parentWindow);
-    fakeAutoUpdater.emit('update-downloaded', { version: '1.0.0' });
-    await flush();
-    await flush();
-
-    expect(showMessageBox).toHaveBeenCalledWith(
-      parentWindow,
-      expect.objectContaining({
-        type: 'info',
-        buttons: ['Restart Now', 'Later'],
-        defaultId: 0,
-        cancelId: 1,
-      })
-    );
-    expect(fakeAutoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
-  });
-
-  it('does NOT call quitAndInstall when user picks Later', async () => {
-    getSettings.mockResolvedValue({ automaticUpdates: true });
-    showMessageBox.mockResolvedValue({ response: 1 });
-
-    await runAutomaticUpdateCheck(parentWindow);
-    fakeAutoUpdater.emit('update-downloaded', { version: '1.0.0' });
-    await flush();
+    await runAutomaticUpdateCheck(win);
+    fakeAutoUpdater.emit('update-downloaded', { version: '2.3.4' });
     await flush();
 
-    expect(showMessageBox).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith('update-downloaded', { version: '2.3.4' });
     expect(fakeAutoUpdater.quitAndInstall).not.toHaveBeenCalled();
   });
 
-  it('falls back to parentless dialog when no window is provided', async () => {
+  it('does not send IPC when window is null', async () => {
     getSettings.mockResolvedValue({ automaticUpdates: true });
-    showMessageBox.mockResolvedValue({ response: 0 });
-
     await runAutomaticUpdateCheck(null);
-    fakeAutoUpdater.emit('update-downloaded', { version: '1.0.0' });
+    fakeAutoUpdater.emit('update-downloaded', { version: '2.3.4' });
     await flush();
-    await flush();
-
-    expect(showMessageBox).toHaveBeenCalledWith(
-      expect.objectContaining({ buttons: ['Restart Now', 'Later'] })
-    );
-    expect(fakeAutoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    // No assertion needed beyond not throwing — the null path is exercised.
+    expect(fakeAutoUpdater.quitAndInstall).not.toHaveBeenCalled();
   });
 
-  it('silently swallows a dialog failure without calling quitAndInstall', async () => {
+  it('does not send IPC when window has been destroyed', async () => {
     getSettings.mockResolvedValue({ automaticUpdates: true });
-    showMessageBox.mockRejectedValueOnce(new Error('dialog broken'));
+    const send = vi.fn();
+    const win = makeWindow({ send, destroyed: true });
 
-    await runAutomaticUpdateCheck(parentWindow);
-    fakeAutoUpdater.emit('update-downloaded', { version: '1.0.0' });
-    await flush();
+    await runAutomaticUpdateCheck(win);
+    fakeAutoUpdater.emit('update-downloaded', { version: '2.3.4' });
     await flush();
 
-    expect(fakeAutoUpdater.quitAndInstall).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 });
 

--- a/src/main/updater/index.ts
+++ b/src/main/updater/index.ts
@@ -1,6 +1,6 @@
 import { autoUpdater, type UpdateInfo } from 'electron-updater';
 import { is } from '@electron-toolkit/utils';
-import { dialog, type BrowserWindow } from 'electron';
+import type { BrowserWindow } from 'electron';
 import { storage } from '../storage';
 
 // Helper function to check for updates with timeout and retry
@@ -108,10 +108,11 @@ export function setupAutoUpdaterEvents(): void {
 }
 
 // Runs at app startup: silently checks for an update and, if one is available,
-// downloads it and shows a native dialog asking the user to restart now or
-// later. All failures are swallowed silently so unsupported platforms (e.g.
-// unsigned macOS builds) never surface errors to the user.
-export async function runAutomaticUpdateCheck(parentWindow: BrowserWindow | null): Promise<void> {
+// downloads it and notifies the renderer (via the `update-downloaded` IPC
+// channel) so the in-app UpdateBanner can prompt the user to restart. All
+// failures are swallowed silently so unsupported platforms (e.g. unsigned
+// macOS builds) never surface errors to the user.
+export async function runAutomaticUpdateCheck(targetWindow: BrowserWindow | null): Promise<void> {
   if (is.dev) return;
 
   let enabled = true;
@@ -128,28 +129,11 @@ export async function runAutomaticUpdateCheck(parentWindow: BrowserWindow | null
     autoUpdater.off('error', onError);
   };
 
-  const onDownloaded = async (): Promise<void> => {
+  const onDownloaded = (info: UpdateInfo): void => {
     autoUpdater.off('update-downloaded', onDownloaded);
     autoUpdater.off('error', onError);
-    const options: Electron.MessageBoxOptions = {
-      type: 'info',
-      buttons: ['Restart Now', 'Later'],
-      defaultId: 0,
-      cancelId: 1,
-      title: 'Update Ready',
-      message: 'Clipless has been updated.',
-      detail: 'Restart now to use the new version, or wait until the next time you quit.',
-    };
-    try {
-      const promise = parentWindow
-        ? dialog.showMessageBox(parentWindow, options)
-        : dialog.showMessageBox(options);
-      const { response } = await promise;
-      if (response === 0) {
-        autoUpdater.quitAndInstall();
-      }
-    } catch {
-      // Silent: never bother the user with auto-update errors.
+    if (targetWindow && !targetWindow.isDestroyed()) {
+      targetWindow.webContents.send('update-downloaded', { version: info.version });
     }
   };
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -8,6 +8,7 @@ declare global {
       checkForUpdates: () => Promise<any>;
       downloadUpdate: () => Promise<any>;
       quitAndInstall: () => Promise<void>;
+      onUpdateDownloaded: (callback: (info: { version: string }) => void) => () => void;
       getClipboardText: () => Promise<string>;
       getClipboardHTML: () => Promise<string>;
       getClipboardRTF: () => Promise<string>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,6 +21,12 @@ const api = {
   checkForUpdates: () => electronAPI.ipcRenderer.invoke('check-for-updates'),
   downloadUpdate: () => electronAPI.ipcRenderer.invoke('download-update'),
   quitAndInstall: () => electronAPI.ipcRenderer.invoke('quit-and-install'),
+  onUpdateDownloaded: (callback: (info: { version: string }) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, info: { version: string }) =>
+      callback(info);
+    electronAPI.ipcRenderer.on('update-downloaded', listener);
+    return () => electronAPI.ipcRenderer.removeListener('update-downloaded', listener);
+  },
 
   // Clipboard APIs
   getClipboardText: () => electronAPI.ipcRenderer.invoke('get-clipboard-text'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider, useTheme } from './providers/theme';
 import { LanguageDetectionProvider } from './providers/languageDetection';
 import { StatusBar } from './components/StatusBar';
 import { SearchBar } from './components/SearchBar';
+import { UpdateBanner } from './components/UpdateBanner';
 import classNames from 'classnames';
 import styles from './App.module.css';
 
@@ -19,6 +20,7 @@ function AppContent(): React.JSX.Element {
             <Clips />
           </div>
           <SearchBar />
+          <UpdateBanner />
           <StatusBar />
         </ClipsProvider>
       </LanguageDetectionProvider>

--- a/src/renderer/src/components/UpdateBanner.module.css
+++ b/src/renderer/src/components/UpdateBanner.module.css
@@ -1,0 +1,107 @@
+.wrapper {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.25s ease-out;
+}
+
+.wrapper.visible {
+  max-height: 3rem;
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  background-color: #1e3a5f;
+  color: #e5e5e5;
+  font-size: 0.875rem;
+  border-top: 1px solid #2c5282;
+  transform: translateY(100%);
+  transition: transform 0.25s ease-out;
+}
+
+.wrapper.visible .banner {
+  transform: translateY(0);
+}
+
+.banner.light {
+  background-color: #e0ecff;
+  color: #1a1a1a;
+  border-top-color: #93c5fd;
+}
+
+.message {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: #6a9ef5;
+}
+
+.banner.light .icon {
+  color: #2563eb;
+}
+
+.text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.restartButton {
+  background-color: #2563eb;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.restartButton:hover {
+  background-color: #1d4ed8;
+}
+
+.dismissButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  background: transparent;
+  border: none;
+  border-radius: 0.25rem;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.7;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.dismissButton:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  opacity: 1;
+}
+
+.banner.light .dismissButton:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}

--- a/src/renderer/src/components/UpdateBanner.test.tsx
+++ b/src/renderer/src/components/UpdateBanner.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { UpdateBanner } from './UpdateBanner';
+
+vi.mock('../providers/theme', () => ({
+  useTheme: () => ({ isLight: false }),
+}));
+
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: ({ icon }: { icon: string }) => <i data-icon={icon} />,
+}));
+
+type UpdateCallback = (info: { version: string }) => void;
+
+const setupOnUpdate = (): {
+  emit: (info: { version: string }) => void;
+  unsubscribe: ReturnType<typeof vi.fn>;
+} => {
+  let cb: UpdateCallback = () => {};
+  const unsubscribe = vi.fn();
+  (window.api.onUpdateDownloaded as ReturnType<typeof vi.fn>).mockImplementation(
+    (callback: UpdateCallback) => {
+      cb = callback;
+      return unsubscribe;
+    }
+  );
+  return { emit: (info) => act(() => cb(info)), unsubscribe };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('UpdateBanner', () => {
+  it('subscribes on mount and unsubscribes on unmount', () => {
+    const { unsubscribe } = setupOnUpdate();
+    const { unmount } = render(<UpdateBanner />);
+    expect(window.api.onUpdateDownloaded).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders hidden by default and reveals the version when an update arrives', () => {
+    const { emit } = setupOnUpdate();
+    const { container } = render(<UpdateBanner />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).not.toMatch(/visible/);
+
+    emit({ version: '1.2.3' });
+
+    expect(wrapper.className).toMatch(/visible/);
+    expect(screen.getByText('Version 1.2.3 available!')).toBeInTheDocument();
+  });
+
+  it('calls window.api.quitAndInstall when Restart Now is clicked', async () => {
+    const { emit } = setupOnUpdate();
+    render(<UpdateBanner />);
+    emit({ version: '1.2.3' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart Now' }));
+    expect(window.api.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and recovers when quitAndInstall fails', async () => {
+    const { emit } = setupOnUpdate();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (window.api.quitAndInstall as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('install fail')
+    );
+
+    render(<UpdateBanner />);
+    emit({ version: '1.2.3' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart Now' }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(errSpy).toHaveBeenCalledWith('Failed to restart for update:', expect.any(Error));
+    errSpy.mockRestore();
+  });
+
+  it('hides the banner when dismiss is clicked', () => {
+    const { emit } = setupOnUpdate();
+    const { container } = render(<UpdateBanner />);
+    emit({ version: '1.2.3' });
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toMatch(/visible/);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss update notification' }));
+    expect(wrapper.className).not.toMatch(/visible/);
+  });
+
+  it('re-shows after dismiss when a new update arrives', () => {
+    const { emit } = setupOnUpdate();
+    const { container } = render(<UpdateBanner />);
+    emit({ version: '1.2.3' });
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss update notification' }));
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).not.toMatch(/visible/);
+
+    emit({ version: '1.2.4' });
+    expect(wrapper.className).toMatch(/visible/);
+    expect(screen.getByText('Version 1.2.4 available!')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/components/UpdateBanner.tsx
+++ b/src/renderer/src/components/UpdateBanner.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classNames from 'classnames';
+import { useTheme } from '../providers/theme';
+import styles from './UpdateBanner.module.css';
+
+export const UpdateBanner: React.FC = () => {
+  const { isLight } = useTheme();
+  const [version, setVersion] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = window.api.onUpdateDownloaded((info) => {
+      setVersion(info.version);
+      setDismissed(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  const handleRestart = async (): Promise<void> => {
+    try {
+      await window.api.quitAndInstall();
+    } catch (error) {
+      console.error('Failed to restart for update:', error);
+    }
+  };
+
+  const handleDismiss = (): void => {
+    setDismissed(true);
+  };
+
+  const visible = version !== null && !dismissed;
+
+  return (
+    <div className={classNames(styles.wrapper, { [styles.visible]: visible })}>
+      <div className={classNames(styles.banner, { [styles.light]: isLight })}>
+        <div className={styles.message}>
+          <FontAwesomeIcon icon="circle-arrow-up" className={styles.icon} />
+          <span className={styles.text}>Version {version} available!</span>
+        </div>
+        <div className={styles.actions}>
+          <button type="button" onClick={handleRestart} className={styles.restartButton}>
+            Restart Now
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className={styles.dismissButton}
+            aria-label="Dismiss update notification"
+            title="Dismiss"
+          >
+            <FontAwesomeIcon icon="xmark" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/src/fontawesome.ts
+++ b/src/renderer/src/fontawesome.ts
@@ -31,6 +31,8 @@ import {
   faFileLines,
   faGear,
   faTriangleExclamation,
+  faCircleArrowUp,
+  faXmark,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -64,5 +66,7 @@ library.add(
   faChevronRight,
   faFileLines,
   faGear,
-  faTriangleExclamation
+  faTriangleExclamation,
+  faCircleArrowUp,
+  faXmark
 );

--- a/src/renderer/src/test-setup.ts
+++ b/src/renderer/src/test-setup.ts
@@ -38,6 +38,8 @@ const createMockApi = () => ({
   quickClipsScanText: vi.fn().mockResolvedValue([]),
   onToggleSearch: vi.fn(),
   removeToggleSearchListeners: vi.fn(),
+  onUpdateDownloaded: vi.fn().mockReturnValue(() => {}),
+  quitAndInstall: vi.fn().mockResolvedValue(undefined),
 });
 
 Object.defineProperty(window, 'api', {


### PR DESCRIPTION
### Summary

- Added an update banner to the main window to prompt user for restart, rather than a native system prompt

#### Added

- `UpdateBanner` component in the main clips window. Hidden by default; when an update finishes downloading it animates up from behind the StatusBar with the message `Version {version} available!`, a blue "Restart Now" button, and an "X" dismiss control on the far right.

#### Changed

- Removed native system prompt in favor of update banner in main window.

#### Fixed

- n/a

#### Removed

- native system prompt
