### PR TITLE
Autostart fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ For now, please know that the security warnings are purely administrative and th
 - **Add Tools**: Settings → Quick Clips → Tools
 - **Set Hotkeys**: Settings → Hotkeys
 - **Adjust Preferences**: Settings → General
+- **Auto Start with System**: Settings → General — launch Clipless automatically when you log in (Windows & macOS)
+- **Start Minimized**: Settings → General — start hidden in the system tray instead of opening a window
 
 ### Example Quick Clips Use Cases
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipless",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipless",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/main/app/index.ts
+++ b/src/main/app/index.ts
@@ -10,8 +10,11 @@ import { applyWindowSettings } from '../window/settings';
 import { applyAutoStart } from '../autoStart';
 
 export async function initializeApp(): Promise<void> {
-  // Set app user model id for windows
-  electronApp.setAppUserModelId('com.electron');
+  // Set app user model id for windows. This must be unique to Clipless: on
+  // Windows it is also used as the registry value name for the autostart login
+  // item, so a shared default (e.g. 'com.electron') would collide with other
+  // Electron apps and let dev builds clobber the installed app's entry.
+  electronApp.setAppUserModelId('com.clipless.app');
 
   // Create window first for better perceived performance
   await initializeWindowSystem();
@@ -63,6 +66,22 @@ export async function initializeApp(): Promise<void> {
 }
 
 export function setupAppEvents(): void {
+  // When a second launch is attempted, the new process quits itself via the
+  // single-instance lock (see index.ts) and fires this event on the primary
+  // instance — surface the existing window instead of starting over.
+  app.on('second-instance', () => {
+    const mainWindow = getMainWindow();
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      if (!mainWindow.isVisible()) {
+        mainWindow.show();
+      }
+      mainWindow.focus();
+    }
+  });
+
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.

--- a/src/main/autoStart/index.test.ts
+++ b/src/main/autoStart/index.test.ts
@@ -3,11 +3,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('electron', () => ({
   app: {
     setLoginItemSettings: vi.fn(),
+    getLoginItemSettings: vi.fn(),
+    isPackaged: true,
   },
 }));
 
 import { app } from 'electron';
-import { applyAutoStart, isAutoStartSupported } from './index';
+import { applyAutoStart, isAutoStartSupported, getAutoStartState } from './index';
 
 describe('autoStart', () => {
   const originalPlatform = process.platform;
@@ -16,8 +18,17 @@ describe('autoStart', () => {
     Object.defineProperty(process, 'platform', { value: platform });
   };
 
+  const setPackaged = (value: boolean): void => {
+    Object.defineProperty(app, 'isPackaged', { value, configurable: true });
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    setPlatform('win32');
+    setPackaged(true);
+    vi.mocked(app.getLoginItemSettings).mockReturnValue({
+      openAtLogin: true,
+    } as unknown as Electron.LoginItemSettings);
   });
 
   afterEach(() => {
@@ -42,26 +53,45 @@ describe('autoStart', () => {
   });
 
   describe('applyAutoStart', () => {
-    it('calls setLoginItemSettings with openAtLogin true on win32', () => {
+    it('clears the legacy entry then enables login on win32', () => {
       setPlatform('win32');
       applyAutoStart(true);
-      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
+
+      expect(app.setLoginItemSettings).toHaveBeenNthCalledWith(1, {
+        openAtLogin: false,
+        name: 'com.electron',
+      });
+      expect(app.setLoginItemSettings).toHaveBeenNthCalledWith(2, { openAtLogin: true });
     });
 
-    it('calls setLoginItemSettings with openAtLogin false on win32', () => {
+    it('clears the legacy entry then disables login on win32', () => {
       setPlatform('win32');
       applyAutoStart(false);
-      expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+
+      expect(app.setLoginItemSettings).toHaveBeenNthCalledWith(1, {
+        openAtLogin: false,
+        name: 'com.electron',
+      });
+      expect(app.setLoginItemSettings).toHaveBeenNthCalledWith(2, { openAtLogin: false });
     });
 
-    it('calls setLoginItemSettings on darwin', () => {
+    it('does not touch the legacy entry on darwin', () => {
       setPlatform('darwin');
       applyAutoStart(true);
+
+      expect(app.setLoginItemSettings).toHaveBeenCalledTimes(1);
       expect(app.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
     });
 
     it('does not call setLoginItemSettings on linux', () => {
       setPlatform('linux');
+      applyAutoStart(true);
+      expect(app.setLoginItemSettings).not.toHaveBeenCalled();
+    });
+
+    it('does not call setLoginItemSettings in an unpackaged (dev) build', () => {
+      setPlatform('win32');
+      setPackaged(false);
       applyAutoStart(true);
       expect(app.setLoginItemSettings).not.toHaveBeenCalled();
     });
@@ -76,6 +106,50 @@ describe('autoStart', () => {
       expect(() => applyAutoStart(true)).not.toThrow();
       expect(consoleSpy).toHaveBeenCalledWith(
         'Failed to apply auto-start setting:',
+        expect.any(Error)
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('getAutoStartState', () => {
+    it('returns the OS openAtLogin value on a packaged build', () => {
+      setPlatform('win32');
+      vi.mocked(app.getLoginItemSettings).mockReturnValue({
+        openAtLogin: true,
+      } as unknown as Electron.LoginItemSettings);
+      expect(getAutoStartState()).toBe(true);
+
+      vi.mocked(app.getLoginItemSettings).mockReturnValue({
+        openAtLogin: false,
+      } as unknown as Electron.LoginItemSettings);
+      expect(getAutoStartState()).toBe(false);
+    });
+
+    it('returns null on linux', () => {
+      setPlatform('linux');
+      expect(getAutoStartState()).toBeNull();
+      expect(app.getLoginItemSettings).not.toHaveBeenCalled();
+    });
+
+    it('returns null in an unpackaged (dev) build', () => {
+      setPlatform('win32');
+      setPackaged(false);
+      expect(getAutoStartState()).toBeNull();
+      expect(app.getLoginItemSettings).not.toHaveBeenCalled();
+    });
+
+    it('returns null and logs when getLoginItemSettings throws', () => {
+      setPlatform('win32');
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(app.getLoginItemSettings).mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+
+      expect(getAutoStartState()).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to read auto-start setting:',
         expect.any(Error)
       );
 

--- a/src/main/autoStart/index.ts
+++ b/src/main/autoStart/index.ts
@@ -1,15 +1,61 @@
 import { app } from 'electron';
 
+/**
+ * Legacy registry value name used by older builds. On Windows, Electron writes
+ * the login-item entry to the `Run` registry key under the app's
+ * AppUserModelId. Earlier versions shipped with the electron-vite template
+ * default (`com.electron`), so their autostart entry lives under that name. We
+ * remove it whenever reconciling so a stale entry can't keep launching the app
+ * after autostart is turned off — and can't cause a duplicate launch while it's
+ * on. The current AppUserModelId is set in app/index.ts.
+ */
+const LEGACY_LOGIN_ITEM_NAME = 'com.electron';
+
+/** Auto-start via OS login items is not supported on Linux. */
 export const isAutoStartSupported = (): boolean => process.platform !== 'linux';
 
+/**
+ * Only packaged builds may manage OS login items. In dev/preview,
+ * `process.execPath` points at `node_modules/electron`, so writing a login item
+ * would register a useless entry at boot and clobber the real install's
+ * autostart entry.
+ */
+const canManageAutoStart = (): boolean => isAutoStartSupported() && app.isPackaged;
+
+/**
+ * Reconcile the OS login-item state with the desired setting. Clears the legacy
+ * Windows entry first so the migration to the current AppUserModelId is
+ * self-healing across upgrades.
+ */
 export const applyAutoStart = (enabled: boolean): void => {
-  if (!isAutoStartSupported()) {
+  if (!canManageAutoStart()) {
     return;
   }
 
   try {
+    if (process.platform === 'win32') {
+      app.setLoginItemSettings({ openAtLogin: false, name: LEGACY_LOGIN_ITEM_NAME });
+    }
     app.setLoginItemSettings({ openAtLogin: enabled });
   } catch (error) {
     console.error('Failed to apply auto-start setting:', error);
+  }
+};
+
+/**
+ * Read the actual OS login-item state. Returns `null` when autostart is not
+ * managed by this process (Linux, or an unpackaged dev/preview build) so callers
+ * can fall back to the persisted setting instead of showing a misleading value.
+ */
+export const getAutoStartState = (): boolean | null => {
+  if (!canManageAutoStart()) {
+    return null;
+  }
+
+  try {
+    return app.getLoginItemSettings().openAtLogin;
+  } catch (error) {
+    console.error('Failed to read auto-start setting:', error);
+    return null;
   }
 };

--- a/src/main/clipboard/ipc.ts
+++ b/src/main/clipboard/ipc.ts
@@ -27,7 +27,7 @@ import {
   importData,
   clearAllData,
 } from './storage-integration';
-import { applyAutoStart } from '../autoStart';
+import { applyAutoStart, getAutoStartState } from '../autoStart';
 import {
   getAllTemplates,
   createTemplate,
@@ -126,6 +126,9 @@ export function setupClipboardIPC(mainWindow: BrowserWindow | null): void {
     applyAutoStart(settings.autoStart);
     return result;
   });
+  // Actual OS login-item state, so the renderer can reflect reality rather than
+  // only the persisted preference. Returns null when not OS-managed (Linux/dev).
+  ipcMain.handle('auto-start-get-state', async () => getAutoStartState());
   ipcMain.handle('storage-get-stats', async () => getStorageStats());
   ipcMain.handle('storage-export-data', async () => exportData());
   ipcMain.handle('storage-import-data', async (_event, jsonData: string) => importData(jsonData));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,16 +1,25 @@
 import { app } from 'electron';
 import { initializeApp, setupAppEvents, initializeServices } from './app';
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.whenReady().then(async () => {
-  // Initialize the main application
-  await initializeApp();
+// Enforce a single running instance. Acquiring the lock fails when another
+// Clipless instance is already running (e.g. the user relaunches it, or
+// autostart fires while it's already open). In that case quit immediately and
+// let the existing instance surface its window via the 'second-instance'
+// handler wired in setupAppEvents().
+if (!app.requestSingleInstanceLock()) {
+  app.quit();
+} else {
+  // This method will be called when Electron has finished
+  // initialization and is ready to create browser windows.
+  // Some APIs can only be used after this event occurs.
+  app.whenReady().then(async () => {
+    // Initialize the main application
+    await initializeApp();
 
-  // Setup app event handlers
-  setupAppEvents();
+    // Setup app event handlers
+    setupAppEvents();
 
-  // Initialize services (IPC, updater, etc.)
-  initializeServices();
-});
+    // Initialize services (IPC, updater, etc.)
+    initializeServices();
+  });
+}

--- a/src/main/window/creation.ts
+++ b/src/main/window/creation.ts
@@ -11,6 +11,7 @@ import {
   calculateWindowPosition,
 } from './settings';
 import { saveWindowBounds, getWindowBounds } from './bounds';
+import { storage } from '../storage';
 import icon from '../../../resources/icon.png?asset';
 
 let mainWindow: BrowserWindow | null = null;
@@ -174,12 +175,28 @@ export async function createWindow(): Promise<void> {
 
   mainWindow = new BrowserWindow(windowOptions);
 
-  mainWindow.on('ready-to-show', () => {
-    if (mainWindow) {
-      mainWindow.show();
-      // Apply window settings after the window is ready
-      applyWindowSettings(mainWindow);
+  mainWindow.on('ready-to-show', async () => {
+    if (!mainWindow) {
+      return;
     }
+
+    // Honor "Start Minimized": keep the window hidden (tray only) on launch
+    // when enabled. Settings load from storage in the background; if they
+    // aren't ready yet this safely defaults to showing the window.
+    let startMinimized = false;
+    try {
+      const settings = await storage.getSettings();
+      startMinimized = settings.startMinimized;
+    } catch (error) {
+      console.error('Failed to read startMinimized setting:', error);
+    }
+
+    if (!startMinimized) {
+      mainWindow.show();
+    }
+
+    // Apply window settings after the window is ready
+    applyWindowSettings(mainWindow);
   });
 
   // Handle window close - minimize to tray instead of quitting

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -31,6 +31,7 @@ declare global {
       openSettings: (tab?: string) => Promise<void>;
       closeSettings: () => Promise<void>;
       getSettings: () => Promise<any>;
+      getAutoStartState: () => Promise<boolean | null>;
       settingsChanged: (settings: any) => Promise<boolean>;
       onSettingsUpdated: (callback: (settings: any) => void) => void;
       removeSettingsListeners: () => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -57,6 +57,8 @@ const api = {
   openSettings: (tab?: string) => electronAPI.ipcRenderer.invoke('open-settings', tab),
   closeSettings: () => electronAPI.ipcRenderer.invoke('close-settings'),
   getSettings: () => electronAPI.ipcRenderer.invoke('get-settings'),
+  getAutoStartState: (): Promise<boolean | null> =>
+    electronAPI.ipcRenderer.invoke('auto-start-get-state'),
   settingsChanged: (settings: UserSettings) =>
     electronAPI.ipcRenderer.invoke('settings-changed', settings),
   onSettingsUpdated: (callback: (settings: UserSettings) => void) => {

--- a/src/renderer/src/components/settings/usersettings/useUserSettings.ts
+++ b/src/renderer/src/components/settings/usersettings/useUserSettings.ts
@@ -22,6 +22,23 @@ export const useUserSettings = () => {
 
       try {
         const loadedSettings = await window.api.storageGetSettings();
+
+        // Reflect the real OS login-item state so the toggle can't silently
+        // drift from what will actually happen at boot (e.g. if a write failed
+        // or an external change occurred). Falls back to the persisted value
+        // when autostart isn't OS-managed — getAutoStartState returns null on
+        // Linux and in unpackaged dev builds.
+        if (window.api.getAutoStartState) {
+          try {
+            const osAutoStart = await window.api.getAutoStartState();
+            if (typeof osAutoStart === 'boolean') {
+              loadedSettings.autoStart = osAutoStart;
+            }
+          } catch (error) {
+            console.error('Failed to read auto-start state:', error);
+          }
+        }
+
         setSettings(loadedSettings);
         setTempMaxClips(loadedSettings.maxClips); // Initialize temp value
       } catch (error) {

--- a/src/renderer/src/test-setup.ts
+++ b/src/renderer/src/test-setup.ts
@@ -33,6 +33,7 @@ const createMockApi = () => ({
     codeDetectionEnabled: true,
   }),
   storageSaveSettings: vi.fn().mockResolvedValue(undefined),
+  getAutoStartState: vi.fn().mockResolvedValue(null),
   onSettingsUpdated: vi.fn().mockReturnValue(() => {}),
   removeSettingsListeners: vi.fn(),
   quickClipsScanText: vi.fn().mockResolvedValue([]),


### PR DESCRIPTION
### Summary

- **Autostart reliability (Windows)**: Fixes "Auto Start with System" not launching Clipless at login, and makes the setting self-healing across upgrades.
- **Single instance**: Clipless now enforces a single running instance and focuses the existing window instead of launching a duplicate — important when autostart fires while the app is already open.
- **Start Minimized**: the previously non-functional setting now actually starts the app hidden in the system tray.
- **Trustworthy toggle**: the General settings toggle now reflects the real OS login-item state, not just the saved preference, so it can't silently drift from what happens at boot.

#### Added

- Single-instance lock via `requestSingleInstanceLock()` in the main entry point, plus a `second-instance` handler that restores/shows/focuses the existing window.
- `getAutoStartState()` in the autoStart module, exposed through a new `auto-start-get-state` IPC channel and `window.api.getAutoStartState()`; the settings toggle now reflects the actual OS login-item state (falls back to the persisted value on Linux/dev).
- `startMinimized` is now honored on launch — when enabled, the window stays hidden in the system tray.
- Unit tests covering the new dev-guard, legacy-entry migration, and OS-state read paths (100% coverage maintained).

#### Changed

- `AppUserModelId` set to `com.clipless.app` (was the electron-vite template default `com.electron`). On Windows this value is used as the autostart registry value name, so a unique ID prevents collisions with other Electron apps and stops dev builds from clobbering the installed app's entry.
- `applyAutoStart` now manages OS login items only in packaged builds (`app.isPackaged`), so `npm run dev` and e2e runs no longer register stray login items pointing at `node_modules/electron`.

#### Fixed

- "Auto Start with System" failing to launch Clipless at login on Windows. Root causes: the generic, shared `com.electron` AppUserModelId used as the login-item registry name, and dev/e2e runs writing stray login items into the user's `Run` key.

#### Removed

- The legacy `com.electron` login-item entry is now cleared automatically during reconciliation (self-healing migration to `com.clipless.app`), so a stale entry can no longer keep launching the app after autostart is turned off — or cause a duplicate launch while it's on.
