### PR TITLE
Scrollbars follow the light and dark theme

### DIFF
--- a/okf-bundle/gotchas/index.md
+++ b/okf-bundle/gotchas/index.md
@@ -7,4 +7,5 @@
 * [E2E on Linux: Playwright forces the basic password store; set CLIPLESS_PLAINTEXT_STORAGE=1](e2e-on-linux-playwright-forces-the-basic-password-store.md)
 * [E2E Tests Touch the Real System Clipboard](e2e-tests-touch-system-clipboard.md)
 * [macOS Builds Are Unsigned](macos-unsigned-builds.md)
+* [Scrollbars are styled once in theme.css](scrollbars-are-styled-once-in-theme-css.md)
 * [Windows startup notification on login-item rewrite](windows-startup-notification-on-login-item-rewrite.md)

--- a/okf-bundle/gotchas/scrollbars-are-styled-once-in-theme-css.md
+++ b/okf-bundle/gotchas/scrollbars-are-styled-once-in-theme-css.md
@@ -1,0 +1,50 @@
+---
+type: gotcha
+title: Scrollbars are styled once in theme.css
+tags:
+  - renderer
+  - ux
+  - theme
+status: stable
+generated:
+  by: okf-mcp/1.4.0
+  at: 2026-08-23T21:52:13.313Z
+sources:
+  - id: theme-css
+    title: src/renderer/src/assets/theme.css
+    type: code
+  - id: rendered-view
+    title: src/renderer/src/components/quick-look/RenderedView.tsx
+    type: code
+---
+
+Chromium's default scrollbar is a light track with arrow buttons. It looked pasted in over
+either theme wherever the app scrolled: the quick look reader, the settings panes, the
+regex textareas.
+
+`src/renderer/src/assets/theme.css` styles it for both windows in one place. `--sb-thumb`,
+`--sb-thumb-hover` and `--sb-thumb-active` are set beside the other theme variables on
+`:root` and on `body.light`; unprefixed `::-webkit-scrollbar` rules give every scrolling
+element a rounded thumb over a transparent track, with `::-webkit-scrollbar-button` hidden
+so no arrows are drawn. `color-scheme` is `dark` on `:root` and `light` on `body.light` so
+anything Chromium still paints itself follows the theme.[^theme-css]
+
+Two things to know before touching this:
+
+- The rules apply to everything, so a component that wants no scrollbar has to opt out.
+  `.clipsContainer` in `Clips.module.css` still hides its own with
+  `.clipsContainer::-webkit-scrollbar { display: none }`, which wins on specificity.
+- The quick look rendered view is an iframe with its own document, so the page's CSS does
+  not reach it. `frameDocument` in `RenderedView.tsx` repeats the scrollbar rules inside
+  the frame's inline `<style>` with the thumb colour resolved by `frameThumbColour()`,
+  which reads `--sb-thumb` off the host document. Change the rules in theme.css and that
+  copy needs the same change.[^rendered-view]
+
+Verifying this in a browser needs one flag: Playwright and Puppeteer launch headless
+Chromium with `--hide-scrollbars`, which makes the gutter measure 0px and hides the thumb
+from screenshots. Launch with `ignoreDefaultArgs: ['--hide-scrollbars']` to see it.
+
+Related: [Quick look engineering calls](../decisions/quick-look-engineering-calls.md).
+
+[^theme-css]: src/renderer/src/assets/theme.css
+[^rendered-view]: src/renderer/src/components/quick-look/RenderedView.tsx

--- a/okf-bundle/log.md
+++ b/okf-bundle/log.md
@@ -1,6 +1,7 @@
 # Update Log
 
 ## 2026-08-23
+* Record how themed scrollbars work and where the iframe copy lives
 * Add text extraction and image metadata at capture, checkClipboardNow; relative links
 * Drop the removed clips.tsx wrapper; add pins, quick look state, scan index and the redesigned clip components
 * Add clip ids, groupColours, toolsSampleText and the storageVersion caveat; relative links

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Clipboard manager for busy people",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/renderer/src/assets/theme.css
+++ b/src/renderer/src/assets/theme.css
@@ -88,6 +88,11 @@
   --orphan: #777777;
   --clip-dot-bd: #666666;
 
+  /* scrollbars (spec 17.8): a thumb over a transparent track, no arrow buttons */
+  --sb-thumb: #4d4d4d;
+  --sb-thumb-hover: #616161;
+  --sb-thumb-active: #767676;
+
   /* syntax token colours for the reader and the editor overlay */
   --tk-key: #7fdbca;
   --tk-str: #ecc48d;
@@ -181,6 +186,10 @@ body.light {
   --orphan: #b5b5b5;
   --clip-dot-bd: #c0c0c0;
 
+  --sb-thumb: #b4b4b4;
+  --sb-thumb-hover: #a0a0a0;
+  --sb-thumb-active: #868686;
+
   --tk-key: #288f7c;
   --tk-str: #9d661a;
   --tk-num: #ae2f09;
@@ -190,6 +199,55 @@ body.light {
   --tk-kw: #691e9a;
   --tk-fn: #003bb8;
   --tk-cm: #676e95;
+}
+
+/*
+ * Scrollbars in both windows. The default Chromium scrollbar is a light track with arrow
+ * buttons and looks pasted in over either theme, so every scrolling element gets a rounded
+ * thumb in the theme's colours over a transparent track. color-scheme keeps anything the
+ * browser still draws itself (form controls, the caret) on the same side of the theme.
+ * .clipsContainer opts out and hides its scrollbar entirely.
+ */
+:root {
+  color-scheme: dark;
+}
+
+body.light {
+  color-scheme: light;
+}
+
+::-webkit-scrollbar {
+  width: 11px;
+  height: 11px;
+}
+
+::-webkit-scrollbar-track,
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--sb-thumb);
+  background-clip: padding-box;
+  border: 3px solid transparent;
+  border-radius: 999px;
+  min-height: 28px;
+  min-width: 28px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--sb-thumb-hover);
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:active {
+  background: var(--sb-thumb-active);
+  background-clip: padding-box;
+}
+
+/* the stepper arrows at the ends of the bar */
+::-webkit-scrollbar-button {
+  display: none;
 }
 
 /* Prism token classes, mapped onto the token variables above */

--- a/src/renderer/src/components/quick-look/RenderedView.test.tsx
+++ b/src/renderer/src/components/quick-look/RenderedView.test.tsx
@@ -6,6 +6,7 @@ import {
   FRAME_HEAD,
   frameDocument,
   frameTextColour,
+  frameThumbColour,
 } from './RenderedView';
 
 const HOSTILE =
@@ -123,5 +124,15 @@ describe('RenderedView', () => {
     document.body.style.setProperty('--text', '#abcdef');
     expect(frameTextColour()).toBe('#abcdef');
     document.body.style.removeProperty('--text');
+  });
+
+  it('gives the frame a scrollbar in the theme colour', () => {
+    const doc = frameDocument('<p>hi</p>', '#123456', '#654321');
+    expect(doc).toContain('::-webkit-scrollbar-thumb{background:#654321');
+    expect(doc).toContain('::-webkit-scrollbar-button{display:none}');
+    expect(frameThumbColour()).toBe('#4d4d4d'); // jsdom has no --sb-thumb variable
+    document.body.style.setProperty('--sb-thumb', '#101010');
+    expect(frameThumbColour()).toBe('#101010');
+    document.body.style.removeProperty('--sb-thumb');
   });
 });

--- a/src/renderer/src/components/quick-look/RenderedView.tsx
+++ b/src/renderer/src/components/quick-look/RenderedView.tsx
@@ -12,15 +12,31 @@ export const FRAME_CSP = "default-src 'none'; style-src 'unsafe-inline'";
 
 export const FRAME_HEAD = `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${FRAME_CSP}">`;
 
-export function frameDocument(sanitisedHtml: string, textColour: string): string {
-  const style = `<style>body{margin:10px 16px;font:13.5px/1.5 Inter,-apple-system,"Segoe UI",Roboto,Ubuntu,sans-serif;color:${textColour};background:transparent}a{color:#3b82f6;pointer-events:none}a:not([href]){color:inherit;text-decoration:none}pre,code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12.5px}table{border-collapse:collapse}td,th{border:1px solid #8884;padding:2px 6px}img{display:none}</style>`;
+export function frameDocument(
+  sanitisedHtml: string,
+  textColour: string,
+  thumbColour = '#4d4d4d'
+): string {
+  // The frame is its own document, so it needs the scrollbar rules from theme.css repeated
+  // here with the colours resolved; without them it draws the default light scrollbar.
+  const scrollbar = `::-webkit-scrollbar{width:11px;height:11px}::-webkit-scrollbar-track,::-webkit-scrollbar-corner{background:transparent}::-webkit-scrollbar-thumb{background:${thumbColour};background-clip:padding-box;border:3px solid transparent;border-radius:999px;min-height:28px}::-webkit-scrollbar-button{display:none}`;
+  const style = `<style>body{margin:10px 16px;font:13.5px/1.5 Inter,-apple-system,"Segoe UI",Roboto,Ubuntu,sans-serif;color:${textColour};background:transparent}a{color:#3b82f6;pointer-events:none}a:not([href]){color:inherit;text-decoration:none}pre,code{font-family:ui-monospace,Menlo,Consolas,monospace;font-size:12.5px}table{border-collapse:collapse}td,th{border:1px solid #8884;padding:2px 6px}img{display:none}${scrollbar}</style>`;
   return `${FRAME_HEAD}${style}</head><body>${sanitisedHtml}</body></html>`;
 }
 
-/** The window's text colour from the theme variables, so the frame follows the theme */
+/** A theme variable's current value, so the frame follows the theme */
+function themeValue(name: string, fallback: string): string {
+  const value = getComputedStyle(document.body).getPropertyValue(name).trim();
+  return value || fallback;
+}
+
 export function frameTextColour(): string {
-  const value = getComputedStyle(document.body).getPropertyValue('--text').trim();
-  return value || '#eeeeee';
+  return themeValue('--text', '#eeeeee');
+}
+
+/** The scrollbar thumb colour the frame's own scrollbar uses */
+export function frameThumbColour(): string {
+  return themeValue('--sb-thumb', '#4d4d4d');
 }
 
 interface RenderedViewProps {
@@ -38,13 +54,19 @@ export function RenderedView({ html, onSanitized }: RenderedViewProps) {
       .htmlSanitize(html)
       .then((result) => {
         if (cancelled) return;
-        setDoc(frameDocument(result.html, frameTextColour()));
+        setDoc(frameDocument(result.html, frameTextColour(), frameThumbColour()));
         onSanitized(result.removed);
       })
       .catch((error) => {
         console.error('Failed to sanitise html for the rendered view:', error);
         if (!cancelled)
-          setDoc(frameDocument('<p>Could not render this clip.</p>', frameTextColour()));
+          setDoc(
+            frameDocument(
+              '<p>Could not render this clip.</p>',
+              frameTextColour(),
+              frameThumbColour()
+            )
+          );
       });
     return () => {
       cancelled = true;


### PR DESCRIPTION
Chromium's default scrollbar is a light track with arrow buttons. It looked pasted in
wherever the app scrolled: the quick look reader, the settings panes, the regex textareas
in the Tools tab.

## What changed

`src/renderer/src/assets/theme.css`

- `--sb-thumb`, `--sb-thumb-hover` and `--sb-thumb-active` sit beside the rest of the theme
  variables, on `:root` and on `body.light`.
- Unprefixed `::-webkit-scrollbar` rules give every scrolling element in both windows an
  11px bar with a rounded thumb over a transparent track. `::-webkit-scrollbar-button` is
  hidden, so no stepper arrows.
- `color-scheme` is `dark` on `:root` and `light` on `body.light`, so anything Chromium
  still paints itself lands on the right side of the theme.

`src/renderer/src/components/quick-look/RenderedView.tsx`

- The rendered view is an iframe with its own document, so the page CSS never reaches it.
  `frameDocument` repeats the scrollbar rules in the frame's inline style with the thumb
  colour resolved by a new `frameThumbColour()`, which reads `--sb-thumb` off the host
  document. Covered by a test.

`.clipsContainer` still hides its scrollbar entirely, which reads as deliberate, and its
class specificity beats the new global rules.

The brain gets `gotchas/scrollbars-are-styled-once-in-theme-css`, mostly so the next person
changing the rules knows about the iframe copy that has to change with them.

Patch bump to 2.0.1.

## Verified

Full unit suite (906) passing, typecheck clean, lint clean, prettier clean. No Electron
binary in this worktree, so I checked the rendering by pointing Chrome at a scratch page
that loads the real `theme.css` and screenshotting both themes: thin rounded thumb,
transparent track, no arrows, in both a scrolling pane and a textarea. Worth knowing if you
repeat that: headless Chromium runs with `--hide-scrollbars`, which measures the gutter at
0px and hides the thumb until you drop the flag.