### PR TITLE
feat(settings): language label on code clips gets its own toggle

### DIFF
--- a/okf-bundle/gotchas/index.md
+++ b/okf-bundle/gotchas/index.md
@@ -6,6 +6,7 @@
 * [Dev Builds Silently Defer to an Installed Instance](dev-builds-defer-to-an-installed-instance.md)
 * [E2E on Linux: Playwright forces the basic password store; set CLIPLESS_PLAINTEXT_STORAGE=1](e2e-on-linux-playwright-forces-the-basic-password-store.md)
 * [E2E Tests Touch the Real System Clipboard](e2e-tests-touch-system-clipboard.md)
+* [Language detection over-labels prose as code](language-detection-over-labels-prose-as-code.md)
 * [macOS Builds Are Unsigned](macos-unsigned-builds.md)
 * [Scrollbars are styled once in theme.css](scrollbars-are-styled-once-in-theme-css.md)
 * [Windows startup notification on login-item rewrite](windows-startup-notification-on-login-item-rewrite.md)

--- a/okf-bundle/gotchas/language-detection-over-labels-prose-as-code.md
+++ b/okf-bundle/gotchas/language-detection-over-labels-prose-as-code.md
@@ -1,0 +1,22 @@
+---
+type: gotcha
+title: Language detection over-labels prose as code
+tags:
+  - quick-clips
+  - ux
+status: stable
+generated:
+  by: okf-mcp/1.4.0
+  at: 2026-08-24T15:11:16.054Z
+sources:
+  - id: dan
+    title: Dan, 2026-08-24, asking for the label toggle
+---
+
+The heuristic detector in `src/renderer/src/utils/languageDetection.ts` often tags copied markdown or plain prose as `python` (or another language), so the row label on text clips was wrong often enough to annoy.[^dan]
+
+Mitigation shipped 2026-08-24: a `showLanguageLabel` user setting (default on, only read while `codeDetectionEnabled` is on) hides the row tag without turning off detection or syntax highlighting. `LanguageDetectionProvider` exposes it as `isLanguageLabelEnabled`, already ANDed with code detection; `TextClip` gates the tag on that flag alone.
+
+The real fix is still open: make `detectLanguage`/`isCode` less eager on prose (markdown headings, sentences with `:` and indentation are common false positives). If detection improves, this toggle stays useful but stops being a workaround.
+
+[^dan]: Dan found "it labels a lot of things `python` when its just some markdown or something".

--- a/okf-bundle/log.md
+++ b/okf-bundle/log.md
@@ -1,5 +1,8 @@
 # Update Log
 
+## 2026-08-24
+* Record the prose-as-python false positive and the showLanguageLabel mitigation
+
 ## 2026-08-23
 * Record how themed scrollbars work and where the iframe copy lives
 * Add text extraction and image metadata at capture, checkClipboardNow; relative links

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A Clipboard manager for busy people",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/main/storage/defaults.ts
+++ b/src/main/storage/defaults.ts
@@ -48,6 +48,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   alwaysOnTop: false,
   rememberWindowPosition: true,
   showNotifications: false,
+  showLanguageLabel: true,
   automaticUpdates: true,
   hotkeys: DEFAULT_HOTKEY_SETTINGS,
 };

--- a/src/renderer/src/components/clips/clip/TextClip.test.tsx
+++ b/src/renderer/src/components/clips/clip/TextClip.test.tsx
@@ -4,10 +4,12 @@ import type { ScanResult } from '../../../../../shared/types';
 import { TextClip } from './TextClip';
 
 let mockIsCodeDetectionEnabled = false;
+let mockIsLanguageLabelEnabled = false;
 
 vi.mock('../../../providers/languageDetection', () => ({
   useLanguageDetection: () => ({
     isCodeDetectionEnabled: mockIsCodeDetectionEnabled,
+    isLanguageLabelEnabled: mockIsLanguageLabelEnabled,
   }),
 }));
 
@@ -45,6 +47,7 @@ const scanOf = (text: string, group: string, value: string): ScanResult => {
 
 beforeEach(() => {
   mockIsCodeDetectionEnabled = false;
+  mockIsLanguageLabelEnabled = false;
   pinsState.togglePins.mockClear();
 });
 
@@ -66,6 +69,7 @@ describe('TextClip display', () => {
   });
 
   it('shows a language tag for code and a chip for every match', () => {
+    mockIsLanguageLabelEnabled = true;
     const text = 'ssh admin@10.0.0.1';
     render(
       <TextClip
@@ -77,6 +81,20 @@ describe('TextClip display', () => {
     expect(screen.getByText('bash')).toBeInTheDocument();
     const chip = screen.getByText('10.0.0.1').closest('[data-key]');
     expect(chip).toHaveAttribute('data-key', 'ip|10.0.0.1');
+  });
+
+  it('hides the language tag when the label setting is off', () => {
+    mockIsLanguageLabelEnabled = false;
+    const text = 'ssh admin@10.0.0.1';
+    render(
+      <TextClip
+        clip={clip(text, { isCode: true, language: 'bash' })}
+        scan={null}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(screen.queryByText('bash')).toBeNull();
+    expect(screen.getByText(text)).toBeInTheDocument();
   });
 
   it('clicking a chip pins and never enters edit', () => {

--- a/src/renderer/src/components/clips/clip/TextClip.tsx
+++ b/src/renderer/src/components/clips/clip/TextClip.tsx
@@ -31,7 +31,7 @@ export const TextClip = ({
   onEditingChange,
   editSeq = 0,
 }: TextClipProps) => {
-  const { isCodeDetectionEnabled } = useLanguageDetection();
+  const { isCodeDetectionEnabled, isLanguageLabelEnabled } = useLanguageDetection();
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const isEmpty = clip.content.trim() === '';
@@ -77,7 +77,7 @@ export const TextClip = ({
     );
   }
 
-  const language = clip.isCode && clip.language ? clip.language : null;
+  const language = isLanguageLabelEnabled && clip.isCode && clip.language ? clip.language : null;
 
   return (
     <span

--- a/src/renderer/src/components/settings/general/Application.tsx
+++ b/src/renderer/src/components/settings/general/Application.tsx
@@ -9,6 +9,7 @@ import w from '../shell/widgets.module.css';
  */
 export function Application() {
   const theme = useSetting('theme');
+  const codeDetection = useSetting('codeDetectionEnabled');
   return (
     <Panel title="Application">
       <ClipsToKeep />
@@ -51,6 +52,12 @@ export function Application() {
         id="codeDetectionEnabled"
         label="Code detection"
         description="Detect the language of text clips and colour them as code in the row tag, the editor and quick look."
+      />
+      <ToggleRow
+        id="showLanguageLabel"
+        label="Language label"
+        description="Show the detected language tag at the left of a code clip's row."
+        dimmed={codeDetection.value !== true}
       />
     </Panel>
   );

--- a/src/renderer/src/components/settings/general/General.test.tsx
+++ b/src/renderer/src/components/settings/general/General.test.tsx
@@ -22,6 +22,7 @@ const stored: UserSettings = {
   rememberWindowPosition: true,
   showNotifications: false,
   codeDetectionEnabled: true,
+  showLanguageLabel: true,
   automaticUpdates: true,
 };
 
@@ -95,6 +96,27 @@ describe('General', () => {
     (window.api as unknown as { platform: string }).platform = 'linux';
     await mount();
     expect(screen.queryByTestId('row-autoStart')).toBeNull();
+  });
+
+  it('dims the language label row while code detection is off', async () => {
+    await mount();
+    expect(screen.getByTestId('toggle-showLanguageLabel')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('toggle-codeDetectionEnabled'));
+    await flush();
+    expect(api().settingsChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ codeDetectionEnabled: false })
+    );
+    expect(screen.getByTestId('toggle-showLanguageLabel')).toBeDisabled();
+  });
+
+  it('writes the language label setting through its toggle', async () => {
+    await mount();
+    fireEvent.click(screen.getByTestId('toggle-showLanguageLabel'));
+    await flush();
+    expect(api().settingsChanged).toHaveBeenCalledWith(
+      expect.objectContaining({ showLanguageLabel: false })
+    );
   });
 
   it('changes the theme through the select', async () => {

--- a/src/renderer/src/providers/languageDetection.tsx
+++ b/src/renderer/src/providers/languageDetection.tsx
@@ -7,6 +7,7 @@ import { detectLanguage, isCode, mapToSyntaxHighlighterLanguage } from '../utils
 
 export interface LanguageDetectionSettings {
   codeDetectionEnabled: boolean;
+  showLanguageLabel: boolean;
 }
 
 export interface DetectedLanguageInfo {
@@ -23,10 +24,13 @@ export interface LanguageDetectionContextType {
   // Language detection functions
   detectTextLanguage: (text: string) => DetectedLanguageInfo;
   isCodeDetectionEnabled: boolean;
+  /** Row tag on code clips; false while code detection is off. */
+  isLanguageLabelEnabled: boolean;
 }
 
 const defaultSettings: LanguageDetectionSettings = {
   codeDetectionEnabled: true,
+  showLanguageLabel: true,
 };
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -35,6 +39,7 @@ export const LanguageDetectionContext = createContext<LanguageDetectionContextTy
   updateSettings: () => {},
   detectTextLanguage: () => ({ language: null, isCode: false, syntaxHighlighterLanguage: 'text' }),
   isCodeDetectionEnabled: true,
+  isLanguageLabelEnabled: true,
 });
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -60,6 +65,8 @@ export function LanguageDetectionProvider({ children }: { children: React.ReactN
             ...prevSettings,
             codeDetectionEnabled:
               storedSettings.codeDetectionEnabled ?? defaultSettings.codeDetectionEnabled,
+            showLanguageLabel:
+              storedSettings.showLanguageLabel ?? defaultSettings.showLanguageLabel,
           }));
         }
       } catch (error) {
@@ -85,6 +92,7 @@ export function LanguageDetectionProvider({ children }: { children: React.ReactN
         const updatedSettings = {
           ...currentSettings,
           codeDetectionEnabled: settings.codeDetectionEnabled,
+          showLanguageLabel: settings.showLanguageLabel,
         };
         await window.api.storageSaveSettings(updatedSettings);
       } catch (error) {
@@ -102,13 +110,17 @@ export function LanguageDetectionProvider({ children }: { children: React.ReactN
     if (!window.api?.onSettingsUpdated) return;
 
     const handleSettingsUpdate = (updatedSettings: Partial<LanguageDetectionSettings>) => {
-      if (updatedSettings && typeof updatedSettings.codeDetectionEnabled === 'boolean') {
-        const enabled = updatedSettings.codeDetectionEnabled;
-        setSettings((prevSettings) => ({
-          ...prevSettings,
-          codeDetectionEnabled: enabled,
-        }));
-      }
+      if (!updatedSettings) return;
+      setSettings((prevSettings) => {
+        const next = { ...prevSettings };
+        if (typeof updatedSettings.codeDetectionEnabled === 'boolean') {
+          next.codeDetectionEnabled = updatedSettings.codeDetectionEnabled;
+        }
+        if (typeof updatedSettings.showLanguageLabel === 'boolean') {
+          next.showLanguageLabel = updatedSettings.showLanguageLabel;
+        }
+        return next;
+      });
     };
 
     return window.api.onSettingsUpdated(handleSettingsUpdate);
@@ -160,6 +172,7 @@ export function LanguageDetectionProvider({ children }: { children: React.ReactN
       updateSettings,
       detectTextLanguage,
       isCodeDetectionEnabled: settings.codeDetectionEnabled,
+      isLanguageLabelEnabled: settings.codeDetectionEnabled && settings.showLanguageLabel,
     }),
     [settings, updateSettings, detectTextLanguage]
   );

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -70,6 +70,7 @@ export interface UserSettings {
   hotkeys?: HotkeySettings;
   theme?: 'light' | 'dark' | 'system';
   codeDetectionEnabled?: boolean;
+  showLanguageLabel?: boolean; // row tag on code clips; only read while code detection is on
   windowTransparency?: number; // 0-100, 0 = fully opaque, 100 = fully transparent
   transparencyEnabled?: boolean;
   opaqueWhenFocused?: boolean;


### PR DESCRIPTION
The language detector guesses wrong often enough (markdown copied off a page gets tagged `python`) that the row tag was more noise than help. This makes the tag a preference instead of a side effect of code detection.

- New `showLanguageLabel` setting, default on. It is only read while code detection is on; with detection off no tags render at all, which also fixes old clips keeping their tags after detection was turned off.
- Settings gains a "Language label" toggle under Code detection, dimmed while detection is off (same pattern as the transparency rows).
- `LanguageDetectionProvider` loads, saves and cross-window-syncs the setting and exposes `isLanguageLabelEnabled` already ANDed with code detection, so `TextClip` checks one flag. Editor highlighting and quick look still follow code detection alone.
- Type tags on other rows (`link`, `html`, `rtf`, image format) are untouched; those are not detection guesses.
- Version bumped to 2.1.0.

The real fix, making `detectLanguage`/`isCode` less eager on prose, stays open and is recorded in the brain (`gotchas/language-detection-over-labels-prose-as-code`).

Tests: full suite passes (909), with new coverage for the hidden tag, the dimmed row, and the settings write.