### PR TITLE
perf: keep Quick Peek responsive as clip data grows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clipless",
-  "version": "1.9.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clipless",
-      "version": "1.9.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clipless",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Clipboard manager for busy people",
   "main": "./out/main/index.js",
   "author": "Daniel Essig",

--- a/src/renderer/src/components/quick-look/Content.tsx
+++ b/src/renderer/src/components/quick-look/Content.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import classNames from 'classnames';
 import type { ScanResult } from '../../../../shared/types';
 import { pinKey } from '../../../../shared/readiness';
 import { Chip } from '../clips/clip/Chip';
-import { groupByMatch, segmentLine, splitLines, tokenizeLine } from './tokens';
+import { groupByMatch, indexedLine, indexLines, segmentLine, tokenizeLine } from './tokens';
 import styles from './QuickLook.module.css';
 
 interface ContentProps {
@@ -23,20 +24,37 @@ interface ContentProps {
 export function Content({ text, language, scan, wrap, litKey, onHover }: ContentProps) {
   const paneRef = useRef<HTMLDivElement>(null);
 
-  const lines = useMemo(() => {
-    return splitLines(text, scan?.matches ?? []).map((line) => {
-      const runs = tokenizeLine(line.text, language);
-      return { ...line, groups: groupByMatch(segmentLine(runs, line.start, line.matches)) };
-    });
-  }, [text, language, scan]);
+  const lineIndex = useMemo(() => indexLines(text, scan?.matches ?? []), [text, scan]);
+  const virtualizer = useVirtualizer({
+    count: lineIndex.starts.length,
+    getScrollElement: () => paneRef.current,
+    estimateSize: () => 20,
+    overscan: 8,
+  });
 
   useEffect(() => {
     if (!litKey || !paneRef.current) return;
-    const first = paneRef.current.querySelector<HTMLElement>(`[data-key="${CSS.escape(litKey)}"]`);
-    if (first && typeof first.scrollIntoView === 'function') {
-      first.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-    }
-  }, [litKey]);
+    const match = scan?.matches.find(
+      (candidate) => pinKey(candidate.group, candidate.value) === litKey
+    );
+    if (!match) return;
+    let line = 0;
+    while (line + 1 < lineIndex.starts.length && lineIndex.starts[line + 1] <= match.start) line++;
+    virtualizer.scrollToIndex(line, { align: 'auto' });
+    const scrollToChip = (): boolean => {
+      const first = paneRef.current?.querySelector<HTMLElement>(
+        `[data-key="${CSS.escape(litKey)}"]`
+      );
+      if (first && typeof first.scrollIntoView === 'function') {
+        first.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+        return true;
+      }
+      return false;
+    };
+    if (scrollToChip()) return;
+    const frame = requestAnimationFrame(scrollToChip);
+    return () => cancelAnimationFrame(frame);
+  }, [litKey, lineIndex, scan, virtualizer]);
 
   // Reset scroll when the clip changes
   useEffect(() => {
@@ -51,36 +69,51 @@ export function Content({ text, language, scan, wrap, litKey, onHover }: Content
       className={classNames(styles.pane, { [styles.wrap]: wrap })}
       data-testid="ql-content"
     >
-      {lines.map((line, i) => (
-        <div key={i} className={classNames(styles.line, { [styles.has]: line.matches.length > 0 })}>
-          <span className={styles.gutter}>{i + 1}</span>
-          <span className={styles.lineText}>
-            {line.groups.map((group, j) => {
-              const spans = group.segments.map((segment, k) => (
-                <span
-                  key={k}
-                  className={segment.classes.map((cls) => `tok-${cls}`).join(' ') || undefined}
-                >
-                  {line.text.slice(segment.start, segment.end)}
-                </span>
-              ));
-              if (!group.match) return spans;
-              const key = pinKey(group.match.group, group.match.value);
-              return (
-                <Chip
-                  key={`m${j}`}
-                  group={group.match.group}
-                  value={group.match.value}
-                  lit={litKey === key}
-                  onHover={onHover}
-                >
-                  {spans}
-                </Chip>
-              );
-            })}
-          </span>
-        </div>
-      ))}
+      <div className={styles.virtualLines} style={{ height: `${virtualizer.getTotalSize()}px` }}>
+        {virtualizer.getVirtualItems().map((virtualLine) => {
+          const line = indexedLine(text, lineIndex, virtualLine.index);
+          const runs = tokenizeLine(line.text, language);
+          const groups = groupByMatch(segmentLine(runs, line.start, line.matches));
+          return (
+            <div
+              key={virtualLine.key}
+              data-index={virtualLine.index}
+              ref={virtualizer.measureElement}
+              className={classNames(styles.line, styles.virtualLine, {
+                [styles.has]: line.matches.length > 0,
+              })}
+              style={{ top: `${virtualLine.start}px` }}
+            >
+              <span className={styles.gutter}>{virtualLine.index + 1}</span>
+              <span className={styles.lineText}>
+                {groups.map((group, j) => {
+                  const spans = group.segments.map((segment, k) => (
+                    <span
+                      key={k}
+                      className={segment.classes.map((cls) => `tok-${cls}`).join(' ') || undefined}
+                    >
+                      {line.text.slice(segment.start, segment.end)}
+                    </span>
+                  ));
+                  if (!group.match) return spans;
+                  const key = pinKey(group.match.group, group.match.value);
+                  return (
+                    <Chip
+                      key={`m${j}`}
+                      group={group.match.group}
+                      value={group.match.value}
+                      lit={litKey === key}
+                      onHover={onHover}
+                    >
+                      {spans}
+                    </Chip>
+                  );
+                })}
+              </span>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/renderer/src/components/quick-look/QuickLook.module.css
+++ b/src/renderer/src/components/quick-look/QuickLook.module.css
@@ -214,6 +214,22 @@
   grid-template-columns: 40px 1fr;
 }
 
+.virtualLines {
+  position: relative;
+  min-width: 100%;
+}
+
+.virtualLine {
+  position: absolute;
+  left: 0;
+  width: max-content;
+  min-width: 100%;
+}
+
+.pane.wrap .virtualLine {
+  width: 100%;
+}
+
 .gutter {
   color: var(--ln);
   text-align: right;

--- a/src/renderer/src/components/quick-look/QuickLook.test.tsx
+++ b/src/renderer/src/components/quick-look/QuickLook.test.tsx
@@ -4,6 +4,28 @@ import type { ClipItem, ScanResult } from '../../../../shared/types';
 import type { QuickLookState } from '../../providers/clips/quickLook';
 import { QuickLook, textMeta } from './QuickLook';
 
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: (options: {
+    count: number;
+    getScrollElement: () => Element | null;
+    estimateSize: () => number;
+  }) => {
+    options.getScrollElement();
+    const size = options.estimateSize();
+    return {
+      getTotalSize: () => options.count * size,
+      getVirtualItems: () =>
+        Array.from({ length: Math.min(12, options.count) }, (_, index) => ({
+          key: index,
+          index,
+          start: index * size,
+        })),
+      measureElement: () => {},
+      scrollToIndex: vi.fn(),
+    };
+  },
+}));
+
 const { state } = vi.hoisted(() => ({
   state: {
     quickLook: {
@@ -49,7 +71,9 @@ const ipScan = (text: string): ScanResult => {
 
 vi.mock('../../providers/clips', async () => {
   const utils = await import('../../providers/clips/utils');
-  const { quickLookPosition } = await import('../../providers/clips/quickLook');
+  const { createQuickLookNavigation, quickLookPosition, targetFromNavigation } = await import(
+    '../../providers/clips/quickLook'
+  );
   const visible = () => state.clips.map((clip, originalIndex) => ({ clip, originalIndex }));
   return {
     clipText: utils.clipText,
@@ -60,6 +84,14 @@ vi.mock('../../providers/clips', async () => {
         state.quickLook.openClipId === null
           ? null
           : quickLookPosition(state.clips, visible(), state.quickLook.openClipId, false),
+      walkTargets: (() => {
+        if (state.quickLook.openClipId === null) return { up: null, down: null };
+        const navigation = createQuickLookNavigation(state.clips, visible());
+        return {
+          up: targetFromNavigation(navigation, state.quickLook.openClipId, -1),
+          down: targetFromNavigation(navigation, state.quickLook.openClipId, 1),
+        };
+      })(),
       closeQuickLook: state.closeQuickLook,
       walkQuickLook: state.walkQuickLook,
       setView: state.setView,
@@ -414,9 +446,7 @@ describe('QuickLook', () => {
     openOn('b');
     render(<QuickLook />);
     expect(screen.getByTestId('ql-header')).toHaveTextContent('link');
-    expect(
-      screen.getByTestId('ql-content').querySelectorAll('[data-testid="ql-content"] > div')
-    ).toHaveLength(2);
+    expect(screen.getByTestId('ql-content').querySelectorAll('[data-index]')).toHaveLength(2);
     expect(screen.getByTestId('ql-side')).toHaveTextContent('No search terms match this clip.');
   });
 
@@ -549,5 +579,16 @@ describe('QuickLook', () => {
     expect(textMeta('')).toBe('0 lines · 0 B');
     expect(textMeta('a')).toBe('1 line · 1 B');
     expect(textMeta('é\nb')).toBe('2 lines · 4 B');
+    expect(textMeta('😀')).toBe('1 line · 4 B');
+  });
+
+  it('renders bounded line work for a very large multiline code clip', () => {
+    const content = Array.from({ length: 10_000 }, (_, i) => `const value${i} = ${i};`).join('\n');
+    state.clips = [{ id: 'large', type: 'text', content, isCode: true, language: 'javascript' }];
+    openOn('large');
+    render(<QuickLook />);
+    expect(screen.getByTestId('ql-header')).toHaveTextContent('10000 lines');
+    expect(screen.getByTestId('ql-content').querySelectorAll('[data-index]')).toHaveLength(12);
+    expect(screen.getByTestId('ql-content').querySelector('[data-index="9999"]')).toBeNull();
   });
 });

--- a/src/renderer/src/components/quick-look/QuickLook.test.tsx
+++ b/src/renderer/src/components/quick-look/QuickLook.test.tsx
@@ -340,6 +340,20 @@ describe('QuickLook', () => {
     expect(lit[0].className).not.toContain('lit');
   });
 
+  it('clears a stale highlighted value when updated scan data no longer contains it', () => {
+    const { rerender } = render(<QuickLook />);
+    const sideChip = screen
+      .getByTestId('ql-group-ip')
+      .querySelector('[data-key="ip|1.1.1.1"]') as HTMLElement;
+    fireEvent.mouseEnter(sideChip);
+
+    state.pendingScan = true;
+    rerender(<QuickLook />);
+
+    expect(screen.getByTestId('ql-side')).toHaveTextContent('Scanning this clip');
+    expect(screen.getByTestId('ql-content').querySelectorAll('.lit')).toHaveLength(0);
+  });
+
   it('e enters edit with the editor at reader size; Enter commits and Esc leaves edit only', () => {
     const { rerender } = render(<QuickLook />);
     fireEvent.keyDown(screen.getByTestId('quick-look'), { key: 'e' });
@@ -580,6 +594,7 @@ describe('QuickLook', () => {
     expect(textMeta('a')).toBe('1 line · 1 B');
     expect(textMeta('é\nb')).toBe('2 lines · 4 B');
     expect(textMeta('😀')).toBe('1 line · 4 B');
+    expect(textMeta('\ud800€')).toBe('1 line · 6 B');
   });
 
   it('renders bounded line work for a very large multiline code clip', () => {

--- a/src/renderer/src/components/quick-look/QuickLook.tsx
+++ b/src/renderer/src/components/quick-look/QuickLook.tsx
@@ -1,14 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
-import {
-  clipText,
-  useClipsActions,
-  useClipsData,
-  useClipsPins,
-  useQuickLook,
-} from '../../providers/clips';
+import { clipText, useClipsActions, useClipsPins, useQuickLook } from '../../providers/clips';
 import { scanKeys } from '../../providers/clips/pins';
-import { walkTarget } from '../../providers/clips/quickLook';
 import { EMPTY_SCAN, useScanIndex } from '../../providers/scan';
 import { useLanguageDetection } from '../../providers/languageDetection';
 import { NARROW_WINDOW, SHORT_WINDOW, useMediaQuery } from '../../hooks/useMediaQuery';
@@ -35,8 +28,21 @@ const isTypingTarget = (target: EventTarget | null): boolean =>
 
 /** "7 lines · 128 B" */
 export function textMeta(text: string): string {
-  const lines = text.length === 0 ? 0 : text.split('\n').length;
-  const bytes = new TextEncoder().encode(text).length;
+  let lines = text.length === 0 ? 0 : 1;
+  let bytes = 0;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code === 10) lines++;
+    if (code < 0x80) bytes++;
+    else if (code < 0x800) bytes += 2;
+    else if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
+      const next = text.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i++;
+      } else bytes += 3;
+    } else bytes += 3;
+  }
   return `${lines} ${lines === 1 ? 'line' : 'lines'} · ${formatBytes(bytes)}`;
 }
 
@@ -51,13 +57,13 @@ export function QuickLook() {
     quickLook,
     openClip,
     position,
+    walkTargets,
     closeQuickLook,
     walkQuickLook,
     setView,
     setEditing,
     toggleWrap,
   } = useQuickLook();
-  const { clips, filteredClips } = useClipsData();
   const { updateClip, copyClipToClipboard } = useClipsActions();
   const { isPinned, togglePins, pins } = useClipsPins();
   const { getScan } = useScanIndex();
@@ -182,8 +188,8 @@ export function QuickLook() {
     }
   };
 
-  const canWalkUp = walkTarget(clips, filteredClips, clip.id, -1) !== null;
-  const canWalkDown = walkTarget(clips, filteredClips, clip.id, 1) !== null;
+  const canWalkUp = walkTargets.up !== null;
+  const canWalkDown = walkTargets.down !== null;
 
   const renderBody = () => {
     if (editing) {

--- a/src/renderer/src/components/quick-look/tokens.test.ts
+++ b/src/renderer/src/components/quick-look/tokens.test.ts
@@ -142,6 +142,14 @@ describe('virtual line index', () => {
       { start: 7, text: 'ef', matches: [last] },
     ]);
   });
+
+  it('ignores scanner matches that cover only a line break', () => {
+    const newline = m('x', '\n', 2);
+    const index = indexLines('ab\ncd', [newline]);
+
+    expect(indexedLine('ab\ncd', index, 0).matches).toEqual([]);
+    expect(indexedLine('ab\ncd', index, 1).matches).toEqual([]);
+  });
 });
 
 describe('prismLanguage', () => {

--- a/src/renderer/src/components/quick-look/tokens.test.ts
+++ b/src/renderer/src/components/quick-look/tokens.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import type { Match } from '../../../../shared/types';
 import {
   groupByMatch,
+  indexedLine,
+  indexLines,
   prismLanguage,
   segmentLine,
   splitLines,
@@ -123,6 +125,22 @@ describe('splitLines', () => {
     const edge = splitLines('ab\ncd', [m('x', 'b\n', 1)]);
     expect(edge[0].matches).toHaveLength(1);
     expect(edge[1].matches).toHaveLength(0);
+  });
+});
+
+describe('virtual line index', () => {
+  it('preserves CRLF offsets, overlap handling, and matches spanning line breaks', () => {
+    const text = 'ab\r\ncd\nef';
+    const crossing = m('x', 'b\r\nc', 1);
+    const overlapping = m('y', 'c', 4);
+    const last = m('z', 'ef', 7);
+    const index = indexLines(text, [crossing, overlapping, last]);
+    expect(index.starts).toEqual([0, 4, 7]);
+    expect(index.starts.map((_, line) => indexedLine(text, index, line))).toEqual([
+      { start: 0, text: 'ab', matches: [crossing] },
+      { start: 4, text: 'cd', matches: [crossing] },
+      { start: 7, text: 'ef', matches: [last] },
+    ]);
   });
 });
 

--- a/src/renderer/src/components/quick-look/tokens.ts
+++ b/src/renderer/src/components/quick-look/tokens.ts
@@ -59,6 +59,57 @@ export interface Line {
   matches: Match[]; // the non-overlapping matches on this line
 }
 
+export interface LineIndex {
+  starts: number[];
+  matchesByLine: ReadonlyMap<number, Match[]>;
+}
+
+const lineForOffset = (starts: readonly number[], offset: number): number => {
+  let low = 0;
+  let high = starts.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (starts[middle] <= offset) low = middle + 1;
+    else high = middle;
+  }
+  return Math.max(0, low - 1);
+};
+
+/** Index line boundaries without allocating a string for every line. */
+export function indexLines(text: string, matches: readonly Match[]): LineIndex {
+  const starts = [0];
+  for (let i = 0; i < text.length; i++) if (text.charCodeAt(i) === 10) starts.push(i + 1);
+
+  const matchesByLine = new Map<number, Match[]>();
+  let lastEnd = -1;
+  for (const match of matches) {
+    if (match.start < lastEnd) continue;
+    lastEnd = match.end;
+    const first = lineForOffset(starts, Math.min(match.start, text.length));
+    const last = lineForOffset(starts, Math.max(0, Math.min(match.end - 1, text.length)));
+    for (let line = first; line <= last; line++) {
+      const start = starts[line];
+      const next = starts[line + 1] ?? text.length;
+      let end = line + 1 < starts.length ? next - 1 : next;
+      if (end > start && text.charCodeAt(end - 1) === 13) end--;
+      if (match.start < end && match.end > start) {
+        const onLine = matchesByLine.get(line) ?? [];
+        onLine.push(match);
+        matchesByLine.set(line, onLine);
+      }
+    }
+  }
+  return { starts, matchesByLine };
+}
+
+export function indexedLine(text: string, index: LineIndex, line: number): Line {
+  const start = index.starts[line];
+  const next = index.starts[line + 1] ?? text.length;
+  let end = line + 1 < index.starts.length ? next - 1 : next;
+  if (end > start && text.charCodeAt(end - 1) === 13) end--;
+  return { start, text: text.slice(start, end), matches: index.matchesByLine.get(line) ?? [] };
+}
+
 /**
  * Prism's token tree for one line, flattened to runs. An unknown language gives one plain
  * run, so the content pane renders the same way for prose.

--- a/src/renderer/src/providers/clips/index.tsx
+++ b/src/renderer/src/providers/clips/index.tsx
@@ -43,10 +43,11 @@ import {
   type QuickLookView,
   type VisibleClip,
   closeState,
+  createQuickLookNavigation,
   hasContent,
   openOn,
-  quickLookPosition,
-  walkTarget,
+  positionFromNavigation,
+  targetFromNavigation,
 } from './quickLook';
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -139,12 +140,10 @@ export function ClipsProvider({ children }: { children: React.ReactNode }) {
   const clipsRef = useRef(clips);
   const isHotkeyOperationRef = useRef(isHotkeyOperation);
   const lastCopiedContentRef = useRef(lastCopiedContent);
-  const pinsRef = useRef(pins);
 
   clipsRef.current = clips;
   isHotkeyOperationRef.current = isHotkeyOperation;
   lastCopiedContentRef.current = lastCopiedContent;
-  pinsRef.current = pins;
 
   // Use language detection settings from the context
   const { isCodeDetectionEnabled } = useLanguageDetection();
@@ -281,23 +280,38 @@ export function ClipsProvider({ children }: { children: React.ReactNode }) {
     setPinMap(pruned);
     setDroppedNotice(notice);
   }, []);
-  usePinPruning(clips, getScan, scanVersion, pinsRef, onPrune);
+  usePinPruning(clips, getScan, scanVersion, pins, onPrune);
   const dismissDroppedNotice = useCallback(() => setDroppedNotice(null), []);
 
   // The reader (spec 17.1): tracks a clip by id
-  const openClip = useMemo(
-    () =>
-      quickLook.openClipId === null
-        ? null
-        : (clips.find((clip) => clip.id === quickLook.openClipId) ?? null),
-    [clips, quickLook.openClipId]
+  const quickLookNavigation = useMemo(
+    () => createQuickLookNavigation(clips, filteredClips),
+    [clips, filteredClips]
   );
+  const openClip = useMemo(() => {
+    if (quickLook.openClipId === null) return null;
+    const row = quickLookNavigation.rowById.get(quickLook.openClipId);
+    return row === undefined ? null : clips[row];
+  }, [clips, quickLook.openClipId, quickLookNavigation]);
   const position = useMemo(
     () =>
       quickLook.openClipId === null
         ? null
-        : quickLookPosition(clips, filteredClips, quickLook.openClipId, isFiltering),
-    [clips, filteredClips, quickLook.openClipId, isFiltering]
+        : positionFromNavigation(quickLookNavigation, quickLook.openClipId, isFiltering),
+    [quickLookNavigation, quickLook.openClipId, isFiltering]
+  );
+  const walkTargets = useMemo(
+    () => ({
+      up:
+        quickLook.openClipId === null
+          ? null
+          : targetFromNavigation(quickLookNavigation, quickLook.openClipId, -1),
+      down:
+        quickLook.openClipId === null
+          ? null
+          : targetFromNavigation(quickLookNavigation, quickLook.openClipId, 1),
+    }),
+    [quickLookNavigation, quickLook.openClipId]
   );
 
   const requestRowFocus = useCallback((index: number) => {
@@ -315,10 +329,10 @@ export function ClipsProvider({ children }: { children: React.ReactNode }) {
   const walkQuickLook = useCallback(
     (direction: -1 | 1) => {
       if (quickLook.openClipId === null) return;
-      const target = walkTarget(clips, filteredClips, quickLook.openClipId, direction);
+      const target = direction === -1 ? walkTargets.up : walkTargets.down;
       if (target !== null) setQuickLook((current) => openOn(current, target));
     },
-    [clips, filteredClips, quickLook.openClipId]
+    [quickLook.openClipId, walkTargets]
   );
   const setView = useCallback((view: QuickLookView) => {
     setQuickLook((current) => ({ ...current, view }));
@@ -431,6 +445,7 @@ export function ClipsProvider({ children }: { children: React.ReactNode }) {
       quickLook,
       openClip,
       position,
+      walkTargets,
       openQuickLook,
       closeQuickLook,
       walkQuickLook,
@@ -445,6 +460,7 @@ export function ClipsProvider({ children }: { children: React.ReactNode }) {
       quickLook,
       openClip,
       position,
+      walkTargets,
       openQuickLook,
       closeQuickLook,
       walkQuickLook,

--- a/src/renderer/src/providers/clips/quickLook.test.ts
+++ b/src/renderer/src/providers/clips/quickLook.test.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { ClipItem } from '../../../../shared/types';
 import {
   INITIAL_QUICK_LOOK,
   closeState,
+  createQuickLookNavigation,
   hasContent,
   openOn,
   quickLookPosition,
+  positionFromNavigation,
+  targetFromNavigation,
   walkTarget,
   walkable,
   type VisibleClip,
@@ -48,12 +51,15 @@ describe('quick look state', () => {
   });
 
   it('treats whitespace-only text and empty images as having no content', () => {
+    const trim = vi.spyOn(String.prototype, 'trim');
     expect(hasContent(clip('a', '  \n'))).toBe(false);
     expect(hasContent(clip('i', '', { type: 'image' }))).toBe(false);
     expect(hasContent(clip('i', 'img-id', { type: 'image', imageId: 'img-id' }))).toBe(true);
     expect(hasContent(clip('b', '', { type: 'bookmark', title: 'T', url: 'https://x' }))).toBe(
       true
     );
+    expect(trim).not.toHaveBeenCalled();
+    trim.mockRestore();
   });
 });
 
@@ -125,5 +131,29 @@ describe('walkTarget', () => {
     expect(walkTarget(clips, all(clips), 'zzz', 1)).toBeNull();
     const onlyLast = all(clips).filter(({ clip: c }) => c.id === 'd');
     expect(walkTarget(clips, onlyLast, 'a', -1)).toBeNull();
+  });
+});
+
+describe('shared navigation model', () => {
+  it('derives content once, then answers position and both neighbours without rereading clips', () => {
+    let reads = 0;
+    const clips = Array.from({ length: 10_000 }, (_, i) => {
+      const item = { id: `c${i}`, type: 'text' as const } as ClipItem;
+      Object.defineProperty(item, 'content', {
+        enumerable: true,
+        get: () => {
+          reads++;
+          return i % 10 === 0 ? '' : `clip ${i}`;
+        },
+      });
+      return item;
+    });
+    const navigation = createQuickLookNavigation(clips, all(clips));
+    expect(reads).toBe(clips.length);
+    reads = 0;
+    expect(positionFromNavigation(navigation, 'c5001', false).label).toBe('4501 / 9000');
+    expect(targetFromNavigation(navigation, 'c5001', -1)).toBe('c4999');
+    expect(targetFromNavigation(navigation, 'c5001', 1)).toBe('c5002');
+    expect(reads).toBe(0);
   });
 });

--- a/src/renderer/src/providers/clips/quickLook.test.ts
+++ b/src/renderer/src/providers/clips/quickLook.test.ts
@@ -61,6 +61,19 @@ describe('quick look state', () => {
     expect(trim).not.toHaveBeenCalled();
     trim.mockRestore();
   });
+
+  it('uses bookmark URL/content fallbacks and extracted rich-text content', () => {
+    expect(hasContent(clip('url', '', { type: 'bookmark', title: ' ', url: 'https://x' }))).toBe(
+      true
+    );
+    expect(hasContent(clip('fallback', 'https://x', { type: 'bookmark' }))).toBe(true);
+    expect(hasContent(clip('empty-bookmark', ' ', { type: 'bookmark' }))).toBe(false);
+    expect(hasContent(clip('html', '<b>markup only</b>', { type: 'html', text: ' ' }))).toBe(false);
+    expect(hasContent(clip('legacy-html', '<b>readable fallback</b>', { type: 'html' }))).toBe(true);
+    expect(hasContent(clip('rtf', '{\\rtf1 markup only}', { type: 'rtf', text: 'readable' }))).toBe(
+      true
+    );
+  });
 });
 
 describe('quickLookPosition', () => {
@@ -131,6 +144,8 @@ describe('walkTarget', () => {
     expect(walkTarget(clips, all(clips), 'zzz', 1)).toBeNull();
     const onlyLast = all(clips).filter(({ clip: c }) => c.id === 'd');
     expect(walkTarget(clips, onlyLast, 'a', -1)).toBeNull();
+    const onlyFirst = all(clips).filter(({ clip: c }) => c.id === 'a');
+    expect(walkTarget(clips, onlyFirst, 'd', 1)).toBeNull();
   });
 });
 

--- a/src/renderer/src/providers/clips/quickLook.ts
+++ b/src/renderer/src/providers/clips/quickLook.ts
@@ -1,5 +1,4 @@
 import type { ClipItem } from '../../../../shared/types';
-import { clipText } from './utils';
 
 /**
  * The reader's state (spec 17.1). It tracks a clip by id, not an index: when a clip lands
@@ -47,7 +46,13 @@ export function closeState(state: QuickLookState): QuickLookState {
 }
 
 export function hasContent(clip: ClipItem): boolean {
-  return clip.type === 'image' ? clip.content.length > 0 : clipText(clip).trim().length > 0;
+  if (clip.type === 'image') return clip.content.length > 0;
+  if (clip.type === 'bookmark') {
+    return /\S/u.test(clip.title ?? '') || /\S/u.test(clip.url ?? clip.content);
+  }
+  return /\S/u.test(
+    clip.type === 'html' || clip.type === 'rtf' ? (clip.text ?? clip.content) : clip.content
+  );
 }
 
 /**
@@ -65,20 +70,73 @@ export interface QuickLookPosition {
   label: string; // "5 / 6", "2 / 5 filtered", "hidden by filter"
 }
 
+export interface QuickLookNavigation {
+  readonly rowById: ReadonlyMap<string, number>;
+  readonly stepById: ReadonlyMap<string, number>;
+  readonly steps: readonly { id: string; originalIndex: number }[];
+}
+
+/** Build once when the clip/filter data changes; opening and walking then only query it. */
+export function createQuickLookNavigation(
+  clips: readonly ClipItem[],
+  visible: readonly VisibleClip[]
+): QuickLookNavigation {
+  const rowById = new Map<string, number>();
+  for (let i = 0; i < clips.length; i++) rowById.set(clips[i].id, i);
+
+  const stepById = new Map<string, number>();
+  const steps: { id: string; originalIndex: number }[] = [];
+  for (const { clip, originalIndex } of visible) {
+    if (!hasContent(clip)) continue;
+    stepById.set(clip.id, steps.length);
+    steps.push({ id: clip.id, originalIndex });
+  }
+  return { rowById, stepById, steps };
+}
+
+export function positionFromNavigation(
+  navigation: QuickLookNavigation,
+  openClipId: string,
+  filtering: boolean
+): QuickLookPosition {
+  const index = navigation.rowById.get(openClipId) ?? -1;
+  const visibleIndex = navigation.stepById.get(openClipId) ?? -1;
+  const hidden = index >= 0 && visibleIndex < 0;
+  const label = hidden
+    ? 'hidden by filter'
+    : `${visibleIndex + 1} / ${navigation.steps.length}${filtering ? ' filtered' : ''}`;
+  return { index, visibleIndex, visibleCount: navigation.steps.length, hidden, label };
+}
+
 export function quickLookPosition(
   clips: readonly ClipItem[],
   visible: readonly VisibleClip[],
   openClipId: string,
   filtering: boolean
 ): QuickLookPosition {
-  const index = clips.findIndex((clip) => clip.id === openClipId);
-  const steps = walkable(visible);
-  const visibleIndex = steps.findIndex(({ clip }) => clip.id === openClipId);
-  const hidden = index >= 0 && visibleIndex < 0;
-  const label = hidden
-    ? 'hidden by filter'
-    : `${visibleIndex + 1} / ${steps.length}${filtering ? ' filtered' : ''}`;
-  return { index, visibleIndex, visibleCount: steps.length, hidden, label };
+  return positionFromNavigation(createQuickLookNavigation(clips, visible), openClipId, filtering);
+}
+
+export function targetFromNavigation(
+  navigation: QuickLookNavigation,
+  openClipId: string,
+  direction: -1 | 1
+): string | null {
+  const at = navigation.stepById.get(openClipId);
+  if (at !== undefined) return navigation.steps[at + direction]?.id ?? null;
+
+  const row = navigation.rowById.get(openClipId);
+  if (row === undefined) return null;
+  let low = 0;
+  let high = navigation.steps.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (navigation.steps[middle].originalIndex < row) low = middle + 1;
+    else high = middle;
+  }
+  return direction === 1
+    ? (navigation.steps[low]?.id ?? null)
+    : (navigation.steps[low - 1]?.id ?? null);
 }
 
 /**
@@ -91,16 +149,5 @@ export function walkTarget(
   openClipId: string,
   direction: -1 | 1
 ): string | null {
-  const steps = walkable(visible);
-  const at = steps.findIndex(({ clip }) => clip.id === openClipId);
-  if (at >= 0) {
-    return steps[at + direction]?.clip.id ?? null;
-  }
-  const row = clips.findIndex((clip) => clip.id === openClipId);
-  if (row < 0) return null;
-  const nearest =
-    direction === 1
-      ? steps.find((s) => s.originalIndex > row)
-      : [...steps].reverse().find((s) => s.originalIndex < row);
-  return nearest?.clip.id ?? null;
+  return targetFromNavigation(createQuickLookNavigation(clips, visible), openClipId, direction);
 }

--- a/src/renderer/src/providers/clips/types.ts
+++ b/src/renderer/src/providers/clips/types.ts
@@ -74,6 +74,7 @@ export type ClipsQuickLookContextType = {
   /** The open clip, or null when the reader is closed */
   openClip: ClipItem | null;
   position: QuickLookPosition | null;
+  walkTargets: { up: string | null; down: string | null };
   openQuickLook: (clipId: string, returnFocusIndex: number | null) => void;
   closeQuickLook: () => void;
   /** Up (-1) or Down (1) to the neighbouring clip with content; no-op at the ends */

--- a/src/renderer/src/providers/clips/usePinPruning.test.tsx
+++ b/src/renderer/src/providers/clips/usePinPruning.test.tsx
@@ -21,22 +21,51 @@ function Probe({
   clips,
   getScan,
   version,
-  pinsRef,
+  pins,
   onPrune,
 }: {
   clips: ClipItem[];
   getScan: (c: ClipItem) => ScanResult | null;
   version: number;
-  pinsRef: React.MutableRefObject<PinMap>;
+  pins: PinMap;
   onPrune: (pins: PinMap, notice: string) => void;
 }) {
-  usePinPruning(clips, getScan, version, pinsRef, onPrune);
+  usePinPruning(clips, getScan, version, pins, onPrune);
   return null;
 }
 
 afterEach(cleanup);
 
 describe('usePinPruning', () => {
+  it('does not scan clips while there are no pins and keeps the later edit reason correct', () => {
+    const getScan = vi.fn((c: ClipItem) => ipScan(c.content));
+    const onPrune = vi.fn();
+    const empty = EMPTY_PINS;
+    const original = [clip('a', 'host 1.1.1.1')];
+    const current = [clip('a', 'host 1.1.1.1 updated')];
+    const { rerender } = render(
+      <Probe clips={original} getScan={getScan} version={0} pins={empty} onPrune={onPrune} />
+    );
+    rerender(
+      <Probe clips={current} getScan={getScan} version={0} pins={empty} onPrune={onPrune} />
+    );
+    expect(getScan).not.toHaveBeenCalled();
+
+    const pins = setPins(empty, ['ip|1.1.1.1'], true, 0);
+    rerender(<Probe clips={current} getScan={getScan} version={0} pins={pins} onPrune={onPrune} />);
+    expect(getScan).toHaveBeenCalledTimes(1);
+    rerender(
+      <Probe
+        clips={[clip('a', 'host updated')]}
+        getScan={getScan}
+        version={0}
+        pins={pins}
+        onPrune={onPrune}
+      />
+    );
+    expect(onPrune.mock.calls[0][1]).toBe('Dropped 1.1.1.1 (ip) after the edit');
+  });
+
   it('drops a pin after an edit removes its value and names the reason', () => {
     const pinsRef = { current: setPins(EMPTY_PINS, ['ip|1.1.1.1'], true, 0) };
     const onPrune = vi.fn();
@@ -46,7 +75,7 @@ describe('usePinPruning', () => {
         clips={[clip('a', 'host 1.1.1.1')]}
         getScan={getScan}
         version={0}
-        pinsRef={pinsRef}
+        pins={pinsRef.current}
         onPrune={onPrune}
       />
     );
@@ -56,7 +85,7 @@ describe('usePinPruning', () => {
         clips={[clip('a', 'host gone')]}
         getScan={getScan}
         version={0}
-        pinsRef={pinsRef}
+        pins={pinsRef.current}
         onPrune={onPrune}
       />
     );
@@ -73,12 +102,12 @@ describe('usePinPruning', () => {
     const getScan = (c: ClipItem) => (pending ? null : ipScan(c.content));
     const clips = [clip('a', 'nothing here')];
     const { rerender } = render(
-      <Probe clips={clips} getScan={getScan} version={0} pinsRef={pinsRef} onPrune={onPrune} />
+      <Probe clips={clips} getScan={getScan} version={0} pins={pinsRef.current} onPrune={onPrune} />
     );
     expect(onPrune).not.toHaveBeenCalled();
     pending = false;
     rerender(
-      <Probe clips={clips} getScan={getScan} version={1} pinsRef={pinsRef} onPrune={onPrune} />
+      <Probe clips={clips} getScan={getScan} version={1} pins={pinsRef.current} onPrune={onPrune} />
     );
     expect(onPrune).toHaveBeenCalledTimes(1);
     expect(onPrune.mock.calls[0][1]).toBe('Dropped 1.1.1.1 (ip) after the search terms changed');
@@ -93,7 +122,7 @@ describe('usePinPruning', () => {
         clips={[clip('a', '1.1.1.1')]}
         getScan={getScan}
         version={0}
-        pinsRef={pinsRef}
+        pins={pinsRef.current}
         onPrune={onPrune}
       />
     );
@@ -102,7 +131,7 @@ describe('usePinPruning', () => {
         clips={[clip('n', 'new'), clip('a', '1.1.1.1')]}
         getScan={getScan}
         version={0}
-        pinsRef={pinsRef}
+        pins={pinsRef.current}
         onPrune={onPrune}
       />
     );

--- a/src/renderer/src/providers/clips/usePinPruning.ts
+++ b/src/renderer/src/providers/clips/usePinPruning.ts
@@ -13,7 +13,7 @@ export function usePinPruning(
   clips: readonly ClipItem[],
   getScan: (clip: ClipItem) => ScanResult | null,
   scanVersion: number,
-  pinsRef: React.MutableRefObject<PinMap>,
+  pins: PinMap,
   onPrune: (pins: PinMap, notice: string) => void
 ): void {
   const prevClipsRef = useRef<readonly ClipItem[]>(clips);
@@ -22,6 +22,13 @@ export function usePinPruning(
   onPruneRef.current = onPrune;
 
   useEffect(() => {
+    if (pins.size === 0) {
+      // There is nothing to validate. Still advance the baseline so a pin added later
+      // cannot make an old clips change look like the reason it disappeared.
+      prevClipsRef.current = clips;
+      keysByClipRef.current = new Map();
+      return;
+    }
     const present = new Set<string>();
     const byClip = new Map<string, Set<string>>();
     for (const clip of clips) {
@@ -31,17 +38,11 @@ export function usePinPruning(
       byClip.set(clip.id, keys);
       for (const key of keys) present.add(key);
     }
-    const result = prunePins(
-      pinsRef.current,
-      present,
-      prevClipsRef.current,
-      clips,
-      keysByClipRef.current
-    );
+    const result = prunePins(pins, present, prevClipsRef.current, clips, keysByClipRef.current);
     prevClipsRef.current = clips;
     keysByClipRef.current = byClip;
     if (result.dropped.length > 0) {
       onPruneRef.current(result.pins, droppedNotice(result.dropped) as string);
     }
-  }, [clips, getScan, scanVersion, pinsRef]);
+  }, [clips, getScan, scanVersion, pins]);
 }


### PR DESCRIPTION
## Summary

- derive Quick Peek navigation once per clip/filter change and reuse indexed position and neighbour lookups
- avoid trimmed full-string allocations and unnecessary empty-pin scans
- virtualize large Quick Peek bodies so only viewport lines are highlighted, segmented, and rendered
- replace allocating text metadata calculations and add bounded-work regression coverage
- bump the patch version to 2.1.1 and synchronize package-lock metadata

## Verification

- npm test: 913 passed
- npm run typecheck: passed
- npm run lint: 0 errors, 38 existing warnings
- npm run build: passed
- git diff --check: passed
